### PR TITLE
Allow --debug flag

### DIFF
--- a/lib/args.js
+++ b/lib/args.js
@@ -38,6 +38,7 @@ var map = {
   cover     : bool,
   node      : bool,
   wd        : bool,
+  debug     : bool,
   reporter  : string,
   ui        : string,
   phantomjs : string,


### PR DESCRIPTION
Without 'debug' in the arguments map, the CLI won't allow it.
