### PR TITLE
cross-spawn shim allows child processes in Windows. Fixes #34

### DIFF
--- a/lib/cover.js
+++ b/lib/cover.js
@@ -9,7 +9,7 @@
 
 var through = require('through2');
 var resolve = require('resolve');
-var spawn   = require('child_process').spawn;
+var spawn   = require('cross-spawn');
 
 
 function coverifySplit(coverifyIn) {

--- a/lib/node.js
+++ b/lib/node.js
@@ -7,7 +7,7 @@
  */
 'use strict';
 
-var spawn        = require('child_process').spawn;
+var spawn        = require('cross-spawn');
 var through      = require('through2');
 var sourceMapper = require('source-mapper');
 var trace        = require('./trace');

--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
     "glob": "^4.0",
     "min-wd": "^2.0",
     "brout": "^1.0",
-    "source-mapper": "^1.0"
+    "source-mapper": "^1.0",
+    "cross-spawn": "^0.2.3"
   },
   "devDependencies": {
     "jslint": "^0.6"

--- a/test/fixture/run.js
+++ b/test/fixture/run.js
@@ -7,7 +7,7 @@
  */
 'use strict';
 
-var spawn  = require('child_process').spawn;
+var spawn  = require('cross-spawn');
 var path   = require('path');
 
 var bin = path.resolve(__dirname, '..', '..', 'bin', 'cmd.js');


### PR DESCRIPTION
Allows mochify to run on Windows
