### PR TITLE
[added] support for grep invert flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Options:
   change.
 - `--reporter` or `-R` changes the Mocha reporter (see further down).
 - `--grep` sets the Mocha grep option.
+- `--invert` sets the Mocha grep `invert` flag.
 - `--ui` or `-U` changes the Mocha UI. Defaults to `'bdd'`.
 - `--timeout` or `-t` changes the Mocha timeout. Defaults to `2000`.
 - `--debug` launches the WebKit debugger.

--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -68,7 +68,8 @@ b.plugin(mocaccino, {
   node     : opts.node,
   yields   : opts.yields,
   timeout  : opts.timeout,
-  grep     : opts.grep
+  grep     : opts.grep,
+  invert   : opts.invert
 });
 
 if (opts.plugin) {

--- a/lib/args.js
+++ b/lib/args.js
@@ -16,7 +16,8 @@ module.exports = function (argv) {
   var opts = subarg(argv, {
     string     : ['reporter', 'ui', 'phantomjs', 'consolify', 'timeout',
                   'port', 'yields', 'transform', 'plugin', 'grep'],
-    boolean    : ['help', 'version', 'watch', 'cover', 'node', 'wd', 'debug'],
+    boolean    : ['help', 'version', 'watch', 'cover', 'node', 'wd',
+                  'debug', 'invert'],
     alias      : {
       help     : 'h',
       version  : 'v',
@@ -70,6 +71,11 @@ module.exports = function (argv) {
       console.log('--debug does not work with --wd\n');
       process.exit(1);
     }
+  }
+
+  if (opts.invert && !opts.grep) {
+    console.log('--invert must be used with --grep option\n');
+    process.exit(1);
   }
 
   var entries = [];

--- a/lib/help.txt
+++ b/lib/help.txt
@@ -11,6 +11,8 @@ Options:
 
             --grep   Set Mocha grep option.
 
+          --invert   Set Mocha grep invert flag.
+
           -U, --ui   Change the Mocha UI. Defaults to 'bdd'.
 
      -t, --timeout   Change the Mocha timeout. Defaults to 2000.

--- a/test/args-test.js
+++ b/test/args-test.js
@@ -142,6 +142,20 @@ describe('args', function () {
     assert.equal(opts.grep, 'foo');
   });
 
+  it('parses --invert', function () {
+    var opts = args(['--invert', '--grep', 'abc']);
+
+    assert(opts.invert);
+  });
+
+  it('fails with invert but no grep option', function (done) {
+    run('passes', ['--invert'], function (code, stdout) {
+      assert.equal(code, 1);
+      assert.equal(stdout, '--invert must be used with --grep option\n\n');
+      done();
+    });
+  });
+
   it('quits with usage', function (done) {
     run('passes', ['--unknown'], function (code, stdout) {
       assert.equal(code, 1);


### PR DESCRIPTION
My primary use case for grep invert support is isomorphic testing
of React components. All tests in a suite that require a DOM can include
a flag, providing a mechanism for node tests to exclude them.

`mochify --node --grep-invert #dom ...`
