### PR TITLE
Add coverify transform after command-line transforms.

### DIFF
--- a/lib/mochify.js
+++ b/lib/mochify.js
@@ -117,10 +117,6 @@ module.exports = function (_, opts) {
   } else {
     b.plugin(phantom, opts);
   }
-  if (opts.cover) {
-    b.transform(coverify);
-    b.plugin(cover);
-  }
 
   entries.forEach(function (entry) {
     b.add(entry);
@@ -152,6 +148,11 @@ module.exports = function (_, opts) {
         basedir: process.cwd()
       }));
     });
+  }
+
+  if (opts.cover) {
+    b.transform(coverify);
+    b.plugin(cover);
   }
 
   b.on('error', error);


### PR DESCRIPTION
If coverify runs before a transform such as [reactify](https://github.com/andreypopp/reactify), it interferes with the JSX transform resulting in failure to run the tests. Moving the converify transform later in the process fixes running test files written in JSX (via `mochify --cover --transform reactify`).

Unfortunately, this does not change the transform ordering for browserify transforms specified in `package.json`. Combining reactify (via `package.json`) and `--cover` will still fail.