### PR TITLE
Add recursive flag to include tests in subdirectories

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Run `mochify --help` to see all available options.
 - `--reporter` or `-R` changes the Mocha reporter (see further down).
 - `--grep` sets the Mocha grep option.
 - `--invert` sets the Mocha grep `invert` flag.
+- `--recursive` include sub directories.
 - `--ui` or `-U` changes the Mocha UI. Defaults to `'bdd'`.
 - `--timeout` or `-t` changes the Mocha timeout. Defaults to `2000`.
 - `--require` or `-r` requires the given module.

--- a/lib/args.js
+++ b/lib/args.js
@@ -10,15 +10,16 @@
 var subarg = require('subarg');
 
 var defaults = {
-  watch    : false,
-  cover    : false,
-  node     : false,
-  debug    : false,
-  wd       : false,
-  reporter : 'dot',
-  timeout  : '2000',
-  port     : '0',
-  yields   : '0'
+  watch     : false,
+  cover     : false,
+  node      : false,
+  debug     : false,
+  wd        : false,
+  recursive : false,
+  reporter  : 'dot',
+  timeout   : '2000',
+  port      : '0',
+  yields    : '0'
 };
 
 function args(argv) {
@@ -27,7 +28,7 @@ function args(argv) {
                   'port', 'yields', 'transform', 'plugin', 'grep', 'url',
                   'require', 'extension'],
     boolean    : ['help', 'version', 'watch', 'cover', 'node', 'wd',
-                  'debug', 'invert'],
+                  'debug', 'invert', 'recursive'],
     alias      : {
       help     : 'h',
       version  : 'v',

--- a/lib/help.txt
+++ b/lib/help.txt
@@ -13,6 +13,8 @@ Options:
 
           --invert   Set Mocha grep invert flag.
 
+       --recursive   include sub directories.
+
           -U, --ui   Change the Mocha UI. Defaults to 'bdd'.
 
      -t, --timeout   Change the Mocha timeout. Defaults to 2000.

--- a/lib/mochify.js
+++ b/lib/mochify.js
@@ -34,6 +34,9 @@ module.exports = function (_, opts) {
   if (!opts.output) {
     opts.output = process.stdout;
   }
+  if (opts.recursive) {
+    _ = './test/**/*.js';
+  }
 
   Object.keys(args.defaults).forEach(function (key) {
     if (!opts.hasOwnProperty(key)) {

--- a/test/args-test.js
+++ b/test/args-test.js
@@ -22,6 +22,7 @@ describe('args', function () {
     assert.equal(opts.cover, false);
     assert.equal(opts.node, false);
     assert.equal(opts.wd, false);
+    assert.equal(opts.recursive, false);
     assert.equal(opts.reporter, 'dot');
     assert.equal(opts.timeout, 2000);
     assert.equal(opts.port, 0);
@@ -170,6 +171,12 @@ describe('args', function () {
     var opts = args(['--invert', '--grep', 'abc']);
 
     assert(opts.invert);
+  });
+
+  it('parses --recursive', function () {
+    var opts = args(['--recursive']);
+
+    assert(opts.recursive);
   });
 
   it('fails with invert but no grep option', function (done) {


### PR DESCRIPTION
Following on from issue #68. Added a `recursive` flag which changes the glob used to find test files to run through Browserify. Imitates Mocha's `recursive` option.

Tests follow on from existing args coverage. I added checks that Mochify accepts the recursive option and sets it correctly. Any suggestions for how to better test this option is doing its job?