### PR TITLE
passthru glob options so I can ignore files

### DIFF
--- a/lib/mochify.js
+++ b/lib/mochify.js
@@ -66,7 +66,7 @@ module.exports = function (_, opts) {
     if (arg.indexOf('*') === -1) {
       entries.push(arg);
     } else {
-      Array.prototype.push.apply(entries, glob.sync(arg));
+      Array.prototype.push.apply(entries, glob.sync(arg, opts.glob || {}));
     }
   });
   if (!entries.length) {

--- a/test/api-test.js
+++ b/test/api-test.js
@@ -90,4 +90,20 @@ describe('api', function () {
     });
   });
 
+  it('should only run 1 test when glob options are passed', function (done) {
+    mochify('./test/fixture/glob/ignore/*.js', {
+      output   : through(),
+      reporter: 'tap',
+      glob: {
+        ignore: './test/fixture/glob/ignore/excluded.js'
+      }
+    }).bundle(function (err, buf) {
+      if (err) {
+        return done(err);
+      }
+      assert(String(buf).indexOf('# tests 1') !== -1);
+      done();
+    });
+  });
+
 });

--- a/test/fixture/glob/ignore/excluded.js
+++ b/test/fixture/glob/ignore/excluded.js
@@ -1,0 +1,10 @@
+/*global describe, it*/
+'use strict';
+
+describe('test', function () {
+
+  it('passes', function () {
+    return;
+  });
+
+});

--- a/test/fixture/glob/ignore/included.js
+++ b/test/fixture/glob/ignore/included.js
@@ -1,0 +1,10 @@
+/*global describe, it*/
+'use strict';
+
+describe('test', function () {
+
+  it('passes', function () {
+    return;
+  });
+
+});

--- a/test/node-test.js
+++ b/test/node-test.js
@@ -46,7 +46,7 @@ describe('node', function () {
         + 'ok 1 test passes\n'
         + '# tests 1\n'
         + '# pass 1\n'
-        + '# fail 0\n\n# coverage: 8/8 (100.00 %)\n\n');
+        + '# fail 0\n# coverage: 8/8 (100.00 %)\n\n');
       assert.equal(code, 0);
       done();
     });

--- a/test/phantom-test.js
+++ b/test/phantom-test.js
@@ -33,7 +33,6 @@ describe('phantom', function () {
       assert.equal(stdout.indexOf('# phantomjs:\n'
         + '1..1\n'
         + 'not ok 1 test fails\n'
-        + '  Error: Oh noes!\n'
         + '      at test/fails.js:7'), 0);
       assert.equal(code, 1);
       done();
@@ -47,7 +46,7 @@ describe('phantom', function () {
         + 'ok 1 test passes\n'
         + '# tests 1\n'
         + '# pass 1\n'
-        + '# fail 0\n\n# coverage: 8/8 (100.00 %)\n\n');
+        + '# fail 0\n# coverage: 8/8 (100.00 %)\n\n');
       assert.equal(code, 0);
       done();
     });


### PR DESCRIPTION
I've structured my app specific code using [local npm modules](http://www.devworkflows.com/posts/using-local-npm-modules-in-npm-v2-0/). 

```
/
  index.js
  package.json
  test/
    index.js
  lib/
    my-local-module/
      index.js
      package.json
      test/
        index.js
  node_modules/ #I want to ignore all test files in this directory
    some-remote-module/
      index.js
      package.json
      test/
        index.js
```

I want to run all the test files in the local modules but not the test files in their dependencies. This PR passes through [glob options](https://www.npmjs.com/package/glob#options) to the `glob` module allowing me to ignore the test files I don't want to run.

```js
mochify('./assets/**/test/*.js', {glob: {ignore: './assets/**/node_modules/**/test/*.js'}});
```

---

In #83 you asked how a similar set of options could be specified from the command line. I'd suggest:

```bash
mochify "./assets/**/test/*.js" --glob.ignore "./assets/**/node_modules/**/test/*.js"
```