### PR TITLE
Only write to input if input stream is defined

### DIFF
--- a/lib/phantom.js
+++ b/lib/phantom.js
@@ -46,14 +46,18 @@ module.exports = function (b, opts) {
 
     wrap.push(through(function (chunk, enc, next) {
       /*jslint unparam: true*/
-      input.write(chunk);
+      if (input) {
+        input.write(chunk);
+      }
       next();
     }, function (next) {
       if (opts.reporter !== 'xunit') {
         opts.output.write('# phantomjs:\n');
       }
       done = next;
-      input.end();
+      if (input) {
+        input.end();
+      }
     }));
 
     wrap.push(output.pipe(trace()));


### PR DESCRIPTION
If there are any syntax errors of any build steps that fail before it makes it to Phantomjs, Mochify stdouts a bunch of unnecessary stack trace data related to the input stream missing. This makes it tedious to track down that it was an error before my tests actually ran and not an error in my tests.