### PR TITLE
add missing output to opts.output

### DIFF
--- a/lib/mochify.js
+++ b/lib/mochify.js
@@ -162,7 +162,6 @@ module.exports = function (_, opts) {
   b.on('error', error);
   b.on('bundle', function (out) {
     out.on('error', error);
-    out.pipe(opts.output);
   });
 
   if (opts.watch) {

--- a/lib/node.js
+++ b/lib/node.js
@@ -57,5 +57,7 @@ module.exports = function (b, opts) {
 
   apply();
   b.on('reset', apply);
-
+  b.on('bundle', function (out) {
+    out.pipe(opts.output);
+  });
 };

--- a/lib/phantom.js
+++ b/lib/phantom.js
@@ -37,6 +37,7 @@ module.exports = function (b, opts) {
         }
       }
     });
+    output.pipe(opts.output);
   }
 
   launch();

--- a/test/phantom-test.js
+++ b/test/phantom-test.js
@@ -42,12 +42,14 @@ describe('phantom', function () {
 
   it('coverage tap', function (done) {
     run('passes', ['--cover', '-R', 'tap'], function (code, stdout) {
-      assert.equal(stdout, '# phantomjs:\n'
-        + '1..1\n'
-        + 'ok 1 test passes\n'
-        + '# tests 1\n'
-        + '# pass 1\n'
-        + '# fail 0\n# coverage: 8/8 (100.00 %)\n\n');
+      var lines = stdout.trim().split(/\n+/);
+      assert.equal(lines[0], '# phantomjs:');
+      assert.equal(lines[9], '1..1');
+      assert.equal(lines[11], 'ok 1 test passes');
+      assert.equal(lines[12], '# tests 1');
+      assert.equal(lines[13], '# pass 1');
+      assert.equal(lines[14], '# fail 0');
+      assert.equal(lines[15], '# coverage: 8/8 (100.00 %)');
       assert.equal(code, 0);
       done();
     });
@@ -57,8 +59,8 @@ describe('phantom', function () {
     run('passes', ['--cover', '--no-colors'], function (code, stdout) {
       var lines = stdout.trim().split(/\n+/);
       assert.equal(lines[0], '# phantomjs:');
-      assert.equal(lines[1], '  .');
-      assert.equal(lines[3], '# coverage: 8/8 (100.00 %)');
+      assert.equal(lines[10], '  .');
+      assert.equal(lines[12], '# coverage: 8/8 (100.00 %)');
       assert.equal(code, 0);
       done();
     });


### PR DESCRIPTION
The phantom output needs to print out somewhere.

I was scratching my head wondering why no output from my test logs was printing, there is that option already to set the output location, so just print it out now.