### PR TITLE
Add the option to ignore ssl errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ Run `mochify --help` to see all available options.
   `phantomjs` is expected on the `$PATH`.
 - `--web-security` enables PhantomJS web security and forbids cross-domain XHR
   (default is true)
+- `--ignore-ssl-errors` tells PhantomJS whether or not to ignore ssl certificate issues 
+  (default is false)
 - `--cover` checks code coverage with [coverify][].
 - `--node` runs test cases on node (useful with `--cover`).
 - `--wd` use [min-webdriver][] to run the tests in multiple real browsers.

--- a/lib/args.js
+++ b/lib/args.js
@@ -16,6 +16,7 @@ var defaults = {
   debug     : false,
   wd        : false,
   recursive : false,
+  'ignore-ssl-errors': false,
   reporter  : 'dot',
   timeout   : '2000',
   port      : '0',
@@ -29,7 +30,8 @@ function args(argv) {
                   'port', 'yields', 'transform', 'plugin', 'grep', 'url',
                   'require', 'extension', 'web-security', 'bundle'],
     boolean    : ['help', 'version', 'watch', 'cover', 'node', 'wd',
-                  'debug', 'invert', 'recursive', 'colors'],
+                  'debug', 'invert', 'recursive', 'colors',
+                  'ignore-ssl-errors'],
     alias      : {
       help     : 'h',
       version  : 'v',

--- a/lib/help.txt
+++ b/lib/help.txt
@@ -3,7 +3,7 @@ Usage: mochify [options] [entry ...]
 Uses PhantomJS unless --wd or --node is specified.
 Defaults "entry" to "./test/*.js".
 
-Options:
+  Options:
        -w, --watch   Use watchify to watch your files and run the tests on
                      change.
 
@@ -38,6 +38,9 @@ Options:
 
     --web-security   Enables PhantomJS web security and forbids cross-domain
                      XHR (default is true)
+
+--ignore-ssl-errors  Tells PhantomJS whether or not to ignore ssl certificate
+                     issues (default is false)
 
            --cover   Check code coverage with coverify.
 

--- a/lib/phantom.js
+++ b/lib/phantom.js
@@ -23,7 +23,8 @@ module.exports = function (b, opts) {
       port           : opts.port,
       brout          : true,
       phantomjs      : opts.phantomjs,
-      'web-security' : opts['web-security']
+      'web-security' : opts['web-security'],
+      'ignore-ssl-errors': opts['ignore-ssl-errors']
     }, function (code) {
       if (code) {
         b.emit('error', new Error('Exit ' + code));

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "coverify": "^1.0",
     "mocaccino": "^1.5",
     "mocha": "^2.0",
-    "phantomic": "^1.1",
+    "phantomic": "^1.2.0",
     "consolify": "^2.0",
     "through2": "^1.1",
     "resolve": "^1.0",

--- a/test/args-test.js
+++ b/test/args-test.js
@@ -27,6 +27,7 @@ describe('args', function () {
     assert.equal(opts.timeout, 2000);
     assert.equal(opts.port, 0);
     assert.equal(opts.yields, 0);
+    assert.equal(opts['ignore-ssl-errors'], false);
   });
 
   it('parses --reporter', function () {
@@ -135,6 +136,11 @@ describe('args', function () {
     var opts = args(['--web-security', 'true']);
 
     assert.equal(opts['web-security'], true);
+  });
+
+  it('parses --ignore-ssl-errors', function () {
+    var opts = args(['--ignore-ssl-errors']);
+    assert(opts['ignore-ssl-errors']);
   });
 
   it('parses --debug', function () {


### PR DESCRIPTION
Pass the new ignore-ssl-errors options to Phantomic.

Ignore PR#98, bottom line was there was an issue of how I was testing where there is no output if a test is running long with a high timeout, no progress indicator was running that a test is running, just a blank console. The fix would be to add an indicator something is running.