### PR TITLE
add postinstall script to use global phantomjs by default; closes #90

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,10 @@ This will install Mochify in your current project and add it to the
 npm install mochify --save-dev
 ```
 
-- Install Phantom.JS: `npm install phantomjs -g` or download from
+- If the `phantomjs` executable *is not* present in your `PATH`, it will be installed locally.
+- If the `phantomjs` executable *is* present in your path, it will not be installed.
+
+- Install PhantomJS: `npm install phantomjs -g` or download from
   <http://phantomjs.org/>
 - Make sure that the `phantomjs` executable is in your `PATH` or use
   `--phantomjs <path>`

--- a/lib/phantom.js
+++ b/lib/phantom.js
@@ -10,19 +10,48 @@
 var through   = require('through2');
 var phantomic = require('phantomic');
 var trace     = require('./trace');
+var which     = require('which');
 
 module.exports = function (b, opts) {
 
   var done;
   var input;
   var output;
+
+  /**
+   * Finds global or local PhantomJS installation and uses its executable
+   * filepath.
+   * Overridden by opts.phantomjs.
+   * @returns {(string|undefined)} Path to PhantomJS executable, if present
+   */
+  function findPhantomJS() {
+    var filepath;
+
+    if (opts.phantomjs) {
+      return opts.phantomjs;
+    }
+
+    try {
+      filepath = which.sync('phantomjs');
+    } catch (e) {
+      // ignored
+      try {
+        filepath = require.resolve('phantomjs/bin/phantomjs');
+      } catch (ignore) {
+        // ignored
+      }
+    }
+    return filepath;
+  }
+
   function launch() {
+    var phantomPath = findPhantomJS();
     input  = through();
     output = phantomic(input, {
       debug          : opts.debug,
       port           : opts.port,
       brout          : true,
-      phantomjs      : opts.phantomjs,
+      phantomjs      : phantomPath,
       'web-security' : opts['web-security'],
       'ignore-ssl-errors': opts['ignore-ssl-errors']
     }, function (code) {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
   "scripts": {
     "lint": "jslint --color \"**/*.js\"",
     "start": "mocha --watch",
-    "test": "npm run lint && mocha"
+    "test": "npm run lint && mocha",
+    "postinstall": "node scripts/postinstall.js"
   },
   "repository": {
     "type": "git",
@@ -60,7 +61,8 @@
     "glob": "^5.0",
     "min-wd": "^2.0",
     "brout": "^1.0",
-    "source-mapper": "^1.0"
+    "source-mapper": "^1.0",
+    "which": "^1.1.1"
   },
   "devDependencies": {
     "jslint": "^0.8"

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+
+'use strict';
+
+/**
+ * This script attempts to find:
+ *
+ * - a locally installed or linked PhantomJS
+ * - a PhantomJS in the PATH
+ *
+ * if neither of those are found, it will install PhantomJS locally.
+ */
+
+function log(msg) {
+  var args = Array.prototype.slice(arguments, 1);
+  args.unshift('=> ' + msg);
+  console.log.apply(console, args);
+}
+
+function installPhantom(callback) {
+  var exec = require('child_process').exec;
+
+  log('Attempting to install PhantomJS locally');
+  var install = exec('npm install phantomjs', function (err) {
+    if (err) {
+      return callback('Failed to install PhantomJS.  Do it manually');
+    }
+    log('Successfully installed PhantomJS.  To link it globally, ' +
+        'execute:\n\tcd node_modules/phantomjs && npm link');
+    callback();
+  });
+  install.stdout.pipe(process.stdout);
+  install.stderr.pipe(process.stderr);
+}
+
+function whichPhantom(callback) {
+  require('which')('phantomjs', function (err) {
+    if (err) {
+      log('PhantomJS not present in PATH');
+      return installPhantom(callback);
+    }
+    log('PhantomJS found in PATH');
+    callback();
+  });
+}
+
+function lstatPhantom(callback) {
+  var localPhantomPath = require('path').join(__dirname,
+      '..',
+      'node_modules',
+      'phantomjs');
+  require('fs').lstat(localPhantomPath, function (err, stats) {
+    if (err) {
+      log('PhantomJS not present locally; checking PATH');
+      return whichPhantom(callback);
+    }
+    if (!stats.isSymbolicLink()) {
+      log('PhantomJS present as local package');
+    } else {
+      log('PhantomJS already linked');
+    }
+    callback();
+  });
+}
+
+function main() {
+  log('Finding PhantomJS');
+
+  lstatPhantom(function (err) {
+    if (err) {
+      return log('Mochify installed with warning(s): ' + err);
+    }
+    log('Mochify install complete!');
+  });
+}
+
+if (require.main === module) {
+  main();
+}
+


### PR DESCRIPTION
- the script first checks to see if there is a local installation of package `phantomjs`
- if not, then it checks the PATH
- if it's not there, it goes ahead and installs it locally
- the `lib/phantom.js` module will default to using the global `phantomjs`, then fallback to local if it cannot be found.  `opts.phantomjs` overrides any of this.
- updated `README.md`
- add `which@^1.1.1` dependency

I wasn't sure how to test if the `phantomjs` executable was found.  since your tests in `test/phantom.js` are more of the integration variety, I figured it's covered if they pass.  Since Travis has it installed globally, we won't get coverage on a local install.  A solution may be to zap `process.env.PATH` and run the `phantom` tests a second time.
