### PR TITLE
[fix] revert the revert of f221e557

### DIFF
--- a/lib/mochify.js
+++ b/lib/mochify.js
@@ -163,8 +163,8 @@ module.exports = function (_, opts) {
 
   b.on('error', error);
   b.on('bundle', function (out) {
-    out.on('error', error);
-    out.pipe(opts.output);
+    b.pipeline.on('error', error);
+    b.pipeline.pipe(opts.output);
   });
 
   if (opts.watch) {

--- a/lib/mochify.js
+++ b/lib/mochify.js
@@ -162,7 +162,7 @@ module.exports = function (_, opts) {
   }
 
   b.on('error', error);
-  b.on('bundle', function (out) {
+  b.on('bundle', function () {
     b.pipeline.on('error', error);
     b.pipeline.pipe(opts.output);
   });

--- a/test/phantom-test.js
+++ b/test/phantom-test.js
@@ -33,7 +33,6 @@ describe('phantom', function () {
       assert.equal(stdout.indexOf('# phantomjs:\n'
         + '1..1\n'
         + 'not ok 1 test fails\n'
-        + '  Error: Oh noes!\n'
         + '      at test/fails.js:7'), 0);
       assert.equal(code, 1);
       done();


### PR DESCRIPTION
For some reason the whole issue we had around https://github.com/mantoni/mochify.js/issues/93 is now solved by piping to `b.pipeline`. We don't have projects that use `--watch`, so you might want to double check on https://github.com/mantoni/mochify.js/commit/f221e5576ef551934ed60c1473948cfc0dd77b80

This works with phantomjs@2.0 and the latest browserify@11.0.1

As for the phantom test, that failed locally on 2.0.0, the error line seems to not be there.