### PR TITLE
Pin Mocaccino to version 1.5 due to breaking change

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "browserify": "^11.0",
     "watchify": "^3.2",
     "coverify": "^1.0",
-    "mocaccino": "^1.5",
+    "mocaccino": "~1.5",
     "mocha": "^2.0",
     "phantomic": "^1.2.0",
     "consolify": "^2.0",


### PR DESCRIPTION
My unit tests are currently failing and the issue seems to point towards an issue with a recently released version of [mocaccino](https://github.com/mantoni/mocaccino.js), version 1.6.

This PR uses the tilde rather than the caret to pin the version to only take minor updates.

Hopefully once mocaccino is fixed this amendment can be reverted.