### PR TITLE
Disable browserField for node tests

### DIFF
--- a/lib/mochify.js
+++ b/lib/mochify.js
@@ -98,6 +98,7 @@ module.exports = function (_, opts) {
   if (opts.node) {
     brOpts.builtins = false;
     brOpts.commondir = false;
+    brOpts.browserField = false;
     brOpts.detectGlobals = false;
     brOpts.insertGlobalVars = ['__dirname', '__filename'];
   }


### PR DESCRIPTION
It will be nice to have this. Codes from "browser" fields are [to complement the features not available in browser](https://github.com/defunctzombie/package-browser-field-spec#overview) and then not suitable for tests directly executed in Node environment.

Also, [browserify's `--node` option](https://github.com/substack/node-browserify#usage) disables this.