### PR TITLE
Implement --browser-field option

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Run `mochify --help` to see all available options.
 - `--plugin` specifies a Browserify plugin to add. Can be specified multiple
   times. Options can be passed with [subargs][].
 - `--extension` search for files with the extension in "require" statements.
+- `--no-browser-field` turns off package.json browser field resolution.
 - `--yields` or `-y` changes the yield interval to allow pending I/O to happen.
 - `--version` or `-v` shows the Mochify version number.
 - `--help` or `-h` shows usage and all available options.
@@ -197,7 +198,8 @@ mochify('./test/*.js', {
 - `mochify(paths, opts)` combines custom paths and options
 
 All long form command line options can be used. E.g. `--node` can be configured
-as `{ node : true }`, `--reporter tab` as `{ reporter : 'tab' }` and so on.
+as `{ node : true }`, `--no-browser-field` as `{ 'browser-field': false }`,
+`--reporter tab` as `{ reporter : 'tab' }` and so on.
 
 Additional API options:
 

--- a/lib/args.js
+++ b/lib/args.js
@@ -17,6 +17,7 @@ var defaults = {
   wd        : false,
   recursive : false,
   'ignore-ssl-errors': false,
+  'browser-field': true,
   reporter  : 'dot',
   timeout   : '2000',
   port      : '0',
@@ -32,7 +33,7 @@ function args(argv) {
                   'wd-file', 'path'],
     boolean    : ['help', 'version', 'watch', 'cover', 'node', 'wd',
                   'debug', 'invert', 'recursive', 'colors',
-                  'ignore-ssl-errors'],
+                  'ignore-ssl-errors', 'browser-field'],
     alias      : {
       help     : 'h',
       version  : 'v',

--- a/lib/help.txt
+++ b/lib/help.txt
@@ -7,7 +7,7 @@ Defaults "entry" to "./test/*.js".
        -w, --watch   Use watchify to watch your files and run the tests on
                      change.
 
-    -R, --reporter   Change the Mocha reporter. 
+    -R, --reporter   Change the Mocha reporter.
                      Mocha reporters known to work:
                      doc, dot (default), json, landing, list, markdown, min,
                      spec, tap, xunit
@@ -65,6 +65,9 @@ Defaults "entry" to "./test/*.js".
        --extension   Search for files with the extension in "require"
                      statements. For example, "--extension .coffee". Can be
                      specified multiple times.
+
+--no-browser-field   Turn off package.json browser field resolution. This is
+                     also handy if you need to run a bundle in node.
 
       -y, --yields   Changes the yield interval to allow pending I/O to happen.
 

--- a/lib/mochify.js
+++ b/lib/mochify.js
@@ -102,6 +102,7 @@ module.exports = function (_, opts) {
     brOpts.insertGlobalVars = ['__dirname', '__filename'];
   }
   brOpts.extensions = opts.extension;
+  brOpts.browserField = opts['browser-field'];
   brOpts.paths = opts.path;
 
   var b = browserify(brOpts);

--- a/test/args-test.js
+++ b/test/args-test.js
@@ -28,6 +28,7 @@ describe('args', function () {
     assert.equal(opts.port, 0);
     assert.equal(opts.yields, 0);
     assert.equal(opts['ignore-ssl-errors'], false);
+    assert.equal(opts['browser-field'], true);
   });
 
   it('parses --reporter', function () {
@@ -213,6 +214,18 @@ describe('args', function () {
     var opts = args(['--no-colors']);
 
     assert.equal(opts.colors, false);
+  });
+
+  it('parses --browser-field', function () {
+    var opts = args(['--browser-field']);
+
+    assert(opts['browser-field']);
+  });
+
+  it('parses --no-browser-field', function () {
+    var opts = args(['--no-browser-field']);
+
+    assert.equal(opts['browser-field'], false);
   });
 
   it('parses --path', function () {

--- a/test/fixture/browser-field/node_modules/some-module/browser.js
+++ b/test/fixture/browser-field/node_modules/some-module/browser.js
@@ -1,0 +1,2 @@
+'use strict';
+module.exports = 'browser';

--- a/test/fixture/browser-field/node_modules/some-module/index.js
+++ b/test/fixture/browser-field/node_modules/some-module/index.js
@@ -1,0 +1,2 @@
+'use strict';
+module.exports = 'index';

--- a/test/fixture/browser-field/node_modules/some-module/package.json
+++ b/test/fixture/browser-field/node_modules/some-module/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "some-module",
+  "version": "1.0.0",
+  "main": "index.js",
+  "browser": "browser.js"
+}

--- a/test/fixture/browser-field/test/browser-field.js
+++ b/test/fixture/browser-field/test/browser-field.js
@@ -1,0 +1,14 @@
+/*global describe, it*/
+'use strict';
+
+var someModule = require('some-module');
+
+describe('browser-field', function () {
+
+  it('passes in browser', function () {
+    if (someModule !== 'browser') {
+      throw new Error();
+    }
+  });
+
+});

--- a/test/node-test.js
+++ b/test/node-test.js
@@ -257,6 +257,32 @@ describe('node', function () {
       });
   });
 
+  it('passes browser-field', function (done) {
+    run('browser-field', ['--node', '-R', 'tap'],
+      function (code, stdout) {
+        assert.equal(stdout, '# node:\n'
+          + '1..1\n'
+          + 'ok 1 browser-field passes in browser\n'
+          + '# tests 1\n'
+          + '# pass 1\n'
+          + '# fail 0\n');
+        assert.equal(code, 0);
+        done();
+      });
+  });
+
+  it('fails browser-field with --browser-field disabled', function (done) {
+    run('browser-field', ['--node', '-R', 'tap', '--no-browser-field'],
+      function (code, stdout) {
+        assert.equal(stdout.indexOf('# node:\n'
+          + '1..1\n'
+          + 'not ok 1 browser-field passes in browser\n'
+          + '  Error'), 0);
+        assert.equal(code, 1);
+        done();
+      });
+  });
+
   // This test case fails on node 0.10 only. The corresponding phantomjs test
   // passes on node 0.10 and 0.12.
   it.skip('shows unicode diff', function (done) {


### PR DESCRIPTION
This is follow-up of #136.

As specified in https://github.com/mantoni/mochify.js/pull/136#issuecomment-214792372, I created fixtures to test against the case where the browser field of test's dependency is involved in the test code. It's located in `test/fixture/browser-field`.