### PR TITLE
Add Test Coverage for --bundle and --consolify args 

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -43,7 +43,6 @@ rules:
     no-return-assign: 2
     no-self-compare: 2
     no-spaced-func: 2
-    no-sync: 2
     no-throw-literal: 2
     no-trailing-spaces: 2
     no-undef-init: 2

--- a/lib/consolify.js
+++ b/lib/consolify.js
@@ -11,7 +11,6 @@ var fs        = require('fs');
 var through   = require('through2');
 var consolify = require('consolify');
 
-
 module.exports = function (b, opts) {
   consolify(b, {
     bundle: opts.bundle

--- a/lib/mochify.js
+++ b/lib/mochify.js
@@ -65,6 +65,11 @@ module.exports = function (_, opts) {
     }
   }
 
+  if (opts.bundle && !opts.consolify) {
+    console.log('--bundle must be used with --consolify option\n');
+    process.exit(1);
+  }
+
   if (opts.invert && !opts.grep) {
     console.log('--invert must be used with --grep option\n');
     process.exit(1);

--- a/package.json
+++ b/package.json
@@ -71,7 +71,8 @@
     "which": "^1.2.1"
   },
   "devDependencies": {
-    "eslint": "^1.10.3"
+    "eslint": "^1.10.3",
+    "tmp": "0.0.28"
   },
   "files": [
     "bin",

--- a/test/api-test.js
+++ b/test/api-test.js
@@ -9,8 +9,10 @@
 'use strict';
 
 var assert  = require('assert');
+var fs      = require('fs');
 var through = require('through2');
 var api     = require('./fixture/api');
+var sandbox = require('./fixture/sandbox');
 var mochify = require('../lib/mochify');
 
 
@@ -117,5 +119,44 @@ describe('api', function () {
       + '# pass 1\n'
       + '# fail 0\n', done));
   });
+
+  it('should write a test-runner html document when --consolify is used',
+    sandbox(function (done, tmpdir) {
+      mochify('./test/fixture/passes/test/*.js', {
+        consolify: tmpdir + '/output.html'
+      }).bundle(function (err) {
+        if (err) {
+          return done(err);
+        }
+        try {
+          fs.statSync(tmpdir + '/output.html');
+          done();
+        } catch (e) {
+          done(e);
+        }
+      });
+    })
+  );
+
+  it('should extract the script to an external bundle when --bundle is used'
+    + ' with --consolify',
+    sandbox(function (done, tmpdir) {
+      mochify('./test/fixture/passes/test/*.js', {
+        consolify: tmpdir + '/output.html',
+        bundle: tmpdir + '/bundle.js'
+      }).bundle(function (err) {
+        if (err) {
+          return done(err);
+        }
+        try {
+          fs.statSync(tmpdir + '/output.html');
+          fs.statSync(tmpdir + '/bundle.js');
+          done();
+        } catch (e) {
+          done(e);
+        }
+      });
+    })
+  );
 
 });

--- a/test/args-test.js
+++ b/test/args-test.js
@@ -291,4 +291,12 @@ describe('args', function () {
     });
   });
 
+  it('fails with bundle but no consolify option', function (done) {
+    run('passes', ['--bundle', 'foo.js'], function (code, stdout) {
+      assert.equal(code, 1);
+      assert.equal(stdout, '--bundle must be used with --consolify option\n\n');
+      done();
+    });
+  });
+
 });

--- a/test/fixture/sandbox.js
+++ b/test/fixture/sandbox.js
@@ -1,0 +1,28 @@
+/*
+ * mochify.js
+ *
+ * Copyright (c) 2014 Maximilian Antoni <mail@maxantoni.de>
+ *
+ * @license MIT
+ */
+'use strict';
+
+var tmp  = require('tmp');
+
+// sandbox creates a temporary directory which will be automatically
+// removed after the testcase completes.
+function sandbox(testfn) {
+  return function (done) {
+    var tmpOpts = {
+      unsafeCleanup: true
+    };
+    tmp.dir(tmpOpts, function (err, tmpdir) {
+      if (err) {
+        return done(err);
+      }
+      testfn(done, tmpdir);
+    });
+  };
+}
+
+module.exports = sandbox;


### PR DESCRIPTION
* Fail with a useful error if the user tries to use --bundle wihout --consolify
* Add test-coverage to check that both the consolify'd HTML and extracted bundle are written to disk