### PR TITLE
Implement --external option

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ Run `mochify --help` to see all available options.
   times. Options can be passed with [subargs][].
 - `--extension` search for files with the extension in "require" statements.
 - `--no-browser-field` turns off package.json browser field resolution.
+- `--external` marks given path or module as external resource and
+  prevent from being loaded into the bundle.
 - `--yields` or `-y` changes the yield interval to allow pending I/O to happen.
 - `--version` or `-v` shows the Mochify version number.
 - `--help` or `-h` shows usage and all available options.

--- a/lib/args.js
+++ b/lib/args.js
@@ -30,7 +30,7 @@ function args(argv) {
     string     : ['reporter', 'ui', 'phantomjs', 'consolify', 'timeout',
                   'port', 'yields', 'transform', 'plugin', 'grep', 'url',
                   'require', 'extension', 'web-security', 'bundle',
-                  'wd-file', 'path'],
+                  'wd-file', 'path', 'external'],
     boolean    : ['help', 'version', 'watch', 'cover', 'node', 'wd',
                   'debug', 'invert', 'recursive', 'colors',
                   'ignore-ssl-errors', 'browser-field'],

--- a/lib/help.txt
+++ b/lib/help.txt
@@ -69,6 +69,9 @@ Defaults "entry" to "./test/*.js".
 --no-browser-field   Turn off package.json browser field resolution. This is
                      also handy if you need to run a bundle in node.
 
+        --external   Mark given path or module as external resource and
+                     prevent from being loaded into the bundle.
+
       -y, --yields   Changes the yield interval to allow pending I/O to happen.
 
      -v, --version   Print mochify version and exit.

--- a/lib/mochify.js
+++ b/lib/mochify.js
@@ -152,6 +152,11 @@ module.exports = function (_, opts) {
 
   b.plugin(mocaccino, mocaccinoOpts);
 
+  if (opts.external) {
+    [].concat(opts.external).forEach(function (x) {
+      b.external(x);
+    });
+  }
   if (opts.plugin) {
     [].concat(opts.plugin).forEach(function (p) {
       if (typeof p === 'string') {

--- a/test/args-test.js
+++ b/test/args-test.js
@@ -234,6 +234,12 @@ describe('args', function () {
     assert.equal(opts.path, './source/');
   });
 
+  it('parses --external', function () {
+    var opts = args(['--external', 'foo']);
+
+    assert.equal(opts.external, 'foo');
+  });
+
   it('defaults colors to null', function () {
     var opts = args([]);
 

--- a/test/fixture/external/test/passes.js
+++ b/test/fixture/external/test/passes.js
@@ -1,0 +1,15 @@
+/*global describe, it*/
+/*eslint no-constant-condition: 0*/
+'use strict';
+
+if (false) {
+  require('unresolvable');
+}
+
+describe('test', function () {
+
+  it('external', function () {
+    return;
+  });
+
+});

--- a/test/node-test.js
+++ b/test/node-test.js
@@ -296,4 +296,29 @@ describe('node', function () {
     });
   });
 
+  it('fails external', function (done) {
+    run('external', ['--node', '-R', 'tap'],
+      function (code, stdout) {
+        assert.equal(
+          stdout.indexOf('Error: Cannot find module \'unresolvable\''),
+          0);
+        assert.equal(code, 1);
+        done();
+      });
+  });
+
+  it('passes external with --external enabled', function (done) {
+    run('external', ['--node', '-R', 'tap', '--external', 'unresolvable'],
+      function (code, stdout) {
+        assert.equal(stdout, '# node:\n'
+          + '1..1\n'
+          + 'ok 1 test external\n'
+          + '# tests 1\n'
+          + '# pass 1\n'
+          + '# fail 0\n');
+        assert.equal(code, 0);
+        done();
+      });
+  });
+
 });


### PR DESCRIPTION
In some situation such as [running enzyme with Browserify](https://github.com/airbnb/enzyme/blob/master/docs/guides/browserify.md), passing `external` option to Browserify is essential. This patch is intended to fill up missing `--external` feature to Mochify.js. Thanks.