### PR TITLE
Added a flag to allow chrome to run as root

### DIFF
--- a/lib/args.js
+++ b/lib/args.js
@@ -34,7 +34,7 @@ function args(argv) {
       'viewport-height', 'outfile', 'https-server'],
     boolean: ['help', 'version', 'watch', 'cover', 'node', 'wd', 'debug',
       'invert', 'recursive', 'colors', 'ignore-ssl-errors', 'browser-field',
-      'commondir'],
+      'commondir', 'allow-chrome-as-root'],
     alias: {
       help: 'h',
       version: 'v',

--- a/lib/chromium.js
+++ b/lib/chromium.js
@@ -41,6 +41,11 @@ module.exports = function (b, opts) {
     ignoreHTTPSErrors: opts['ignore-ssl-errors'],
     args: ['--allow-insecure-localhost']
   };
+
+  if (opts['allow-chrome-as-root']) {
+    options.args.push('--no-sandbox', '--disable-setuid-sandbox');
+  }
+
   if (opts.chrome) {
     options.executablePath = opts.chrome;
   }

--- a/test/args-test.js
+++ b/test/args-test.js
@@ -26,6 +26,7 @@ describe('args', function () {
     assert.equal(opts.reporter, 'spec');
     assert.equal(opts.timeout, 2000);
     assert.equal(opts.yields, 0);
+    assert.equal(opts['allow-chrome-as-root'], false);
     assert.equal(opts['ignore-ssl-errors'], false);
     assert.equal(opts['browser-field'], true);
     assert.equal(opts.commondir, true);
@@ -267,6 +268,12 @@ describe('args', function () {
     var opts = args(['--https-server', '8080']);
 
     assert.equal(opts['https-server'], '8080');
+  });
+
+  it('parses --allow-chrome-as-root', function () {
+    var opts = args(['--allow-chrome-as-root']);
+
+    assert(opts['allow-chrome-as-root']);
   });
 
   it('defaults colors to null', function () {


### PR DESCRIPTION
See https://github.com/GoogleChrome/puppeteer/blob/master/docs/troubleshooting.md#chrome-headless-fails-due-to-sandbox-issues

This passes  the mentioned flags above to chrome: `--no-sandbox --disable-setuid-sandbox`.

These are required to run Chrome as the root user. This fixes #162.