### PR TITLE
Improve port handling for https server

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ the test framework.
     - Supports watch-mode with pre-loaded Chrome page (with `--watch`)
     - Use the Chrome developer tools for debugging ([docs](#debugging))
     - Load tests in the context of a file or URL (with `--url`)
-    - Optional built-in HTTPS server (with `--https-server 8080`)
+    - Optional built-in HTTPS server (with `--https-server`)
 - Run tests in real browsers
     - Supports [SauceLabs][] ([docs](#saucelabs-setup))
     - Supports [WebDriver][] ([docs](#selenium-webdriver-setup))
@@ -101,7 +101,7 @@ break at the `debugger` statement.
 - `--ignore-ssl-errors` tells Chrome whether or not to ignore ssl certificate
   issues (default is false)
 - `--allow-chrome-as-root` allows Chrome to run as root
-- `--https-server` launches an HTTPS server on the specified port and default
+- `--https-server` launches an HTTPS server on the specified port, if no port is given a random available port will be used.
   `--url` to `https://localhost:${port}`
 - `--viewport-width` tells Chrome to use a certain width for its viewport.
 - `--viewport-height` tells Chrome to use a certain height for its viewport.

--- a/lib/args.js
+++ b/lib/args.js
@@ -22,8 +22,7 @@ var defaults = {
   reporter: 'spec',
   timeout: '2000',
   yields: '0',
-  colors: null,
-  'https-server': null
+  colors: null
 };
 
 function args(argv) {
@@ -72,6 +71,10 @@ function args(argv) {
         opts[prop] = parseInt(opts[prop], 10);
       }
     });
+
+  if (opts.hasOwnProperty('https-server')) {
+    opts['https-server'] = parseInt(opts['https-server'], 10) || 0;
+  }
 
   if (opts.hasOwnProperty('web-security')) {
     opts['web-security'] = opts['web-security'] === 'true';

--- a/lib/chromium.js
+++ b/lib/chromium.js
@@ -158,10 +158,7 @@ module.exports = function (b, opts) {
   };
 
   var serverPort = opts['https-server'];
-  if (serverPort) {
-    if (!opts.url) {
-      opts.url = 'https://localhost:' + serverPort;
-    }
+  if (Number.isInteger(serverPort)) {
     server = https.createServer({
       key: fs.readFileSync(path.join(__dirname, '..', 'fixture', 'key.pem')),
       cert: fs.readFileSync(path.join(__dirname, '..', 'fixture', 'cert.pem')),
@@ -182,10 +179,15 @@ module.exports = function (b, opts) {
         });
       }
     });
-    server.listen(serverPort, function (err) {
-      if (err) {
-        b.emit('error', err);
-        finish();
+
+    server.on('error', function (err) {
+      b.emit('error', err);
+      finish();
+    });
+
+    server.listen(serverPort, function () {
+      if (!opts.url) {
+        opts.url = 'https://localhost:' + server.address().port;
       }
     });
   }

--- a/test/args-test.js
+++ b/test/args-test.js
@@ -30,7 +30,6 @@ describe('args', function () {
     assert.equal(opts['ignore-ssl-errors'], false);
     assert.equal(opts['browser-field'], true);
     assert.equal(opts.commondir, true);
-    assert.equal(opts['https-server'], null);
   });
 
   it('parses --reporter', function () {
@@ -272,8 +271,10 @@ describe('args', function () {
 
   it('parses --https-server', function () {
     var opts = args(['--https-server', '8080']);
+    assert.strictEqual(opts['https-server'], 8080);
 
-    assert.equal(opts['https-server'], '8080');
+    var noValueOpts = args(['--https-server']);
+    assert.strictEqual(noValueOpts['https-server'], 0);
   });
 
   it('parses --allow-chrome-as-root', function () {

--- a/test/fixture/port/test/port.js
+++ b/test/fixture/port/test/port.js
@@ -1,0 +1,12 @@
+/*global describe, it, location*/
+'use strict';
+
+var assert = require('assert');
+
+describe('port', function () {
+  it('passes after printing protocol and port', function () {
+    console.log('location.protocol = ' + location.protocol);
+    console.log('location.port = ' + location.port);
+    assert(true);
+  });
+});


### PR DESCRIPTION
When no port is given for the --https-server arg, pick a random free one.
When a port is specified but already in use, fail with a meaningful error message.

This would solve #165 and #164.

I'm unsure about a few things, so I'll also leave comments in the diff.