### PR TITLE
Enable passing of url without additionally specifying port

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,8 +101,7 @@ break at the `debugger` statement.
 - `--ignore-ssl-errors` tells Chrome whether or not to ignore ssl certificate
   issues (default is false)
 - `--allow-chrome-as-root` allows Chrome to run as root
-- `--https-server` launches an HTTPS server on the specified port, if no port is given a random available port will be used.
-  `--url` to `https://localhost:${port}`
+- `--https-server` launches an HTTPS server on the specified port. If no port is given a random available port will be used.
 - `--viewport-width` tells Chrome to use a certain width for its viewport.
 - `--viewport-height` tells Chrome to use a certain height for its viewport.
 - `--cover` checks code coverage with [coverify][].

--- a/lib/args.js
+++ b/lib/args.js
@@ -76,6 +76,17 @@ function args(argv) {
   if (opts.hasOwnProperty('url')) {
     opts.url = url.parse(opts.url);
     delete opts.url.host;
+
+    if (opts.hasOwnProperty('https-server')) {
+      if (opts['https-server'] !== opts.url.port) {
+        console.log(
+          'The port values in --https-server and --url did not match,'
+          + ' got "' + opts['https-server'] + '" and "' + opts.url.port + '".\n'
+          + 'You should be able to use the --url option only.'
+        );
+        process.exit(1);
+      }
+    }
   }
 
   if (opts.hasOwnProperty('https-server')) {

--- a/lib/args.js
+++ b/lib/args.js
@@ -8,6 +8,7 @@
 'use strict';
 
 var subarg = require('subarg');
+var url = require('url');
 
 var defaults = {
   watch: false,
@@ -72,8 +73,15 @@ function args(argv) {
       }
     });
 
+  if (opts.hasOwnProperty('url')) {
+    opts.url = url.parse(opts.url);
+    delete opts.url.host;
+  }
+
   if (opts.hasOwnProperty('https-server')) {
     opts['https-server'] = parseInt(opts['https-server'], 10) || 0;
+  } else if (opts.hasOwnProperty('url')) {
+    opts['https-server'] = parseInt(opts.url.port, 10) || 0;
   }
 
   if (opts.hasOwnProperty('web-security')) {

--- a/lib/chromium.js
+++ b/lib/chromium.js
@@ -8,6 +8,7 @@
 'use strict';
 
 var fs = require('fs');
+var url = require('url');
 var path = require('path');
 var https = require('https');
 var through = require('through2');
@@ -129,8 +130,8 @@ module.exports = function (b, opts) {
 
       // We need a "real" web page loaded from a URL, or things like
       // localStorage are disabled.
-      var url = opts.url || DEFAULT_URL;
-      page.goto(url).then(function () {
+      var pageUrl = opts.url ? url.format(opts.url) : DEFAULT_URL;
+      page.goto(pageUrl).then(function () {
         if (!input) {
           // Bundle error.
           pageFinish();
@@ -187,7 +188,9 @@ module.exports = function (b, opts) {
 
     server.listen(serverPort, function () {
       if (!opts.url) {
-        opts.url = 'https://localhost:' + server.address().port;
+        opts.url = url.parse('https://localhost:' + server.address().port);
+      } else {
+        opts.url.port = server.address().port;
       }
     });
   }

--- a/test/args-test.js
+++ b/test/args-test.js
@@ -93,9 +93,16 @@ describe('args', function () {
   });
 
   it('parses --url', function () {
-    var opts = args(['--url', 'localhost']);
+    var opts = args(['--url', 'https://localhost:8080/test.html']);
 
-    assert.equal(opts.url, 'localhost');
+    assert.equal(opts.url.href, 'https://localhost:8080/test.html');
+    assert.equal(opts['https-server'], 8080);
+
+    var withPort = args(
+      ['--url', 'https://localhost:8080/test.html', '--https-server', '4040']
+    );
+    assert.equal(withPort.url.href, 'https://localhost:8080/test.html');
+    assert.equal(withPort['https-server'], 4040);
   });
 
   it('parses --wd-file', function () {

--- a/test/args-test.js
+++ b/test/args-test.js
@@ -97,12 +97,29 @@ describe('args', function () {
 
     assert.equal(opts.url.href, 'https://localhost:8080/test.html');
     assert.equal(opts['https-server'], 8080);
+  });
 
-    var withPort = args(
-      ['--url', 'https://localhost:8080/test.html', '--https-server', '4040']
-    );
-    assert.equal(withPort.url.href, 'https://localhost:8080/test.html');
-    assert.equal(withPort['https-server'], 4040);
+  context('with conflicting values given', function () {
+    var nativeExit;
+    var exitCalledWith;
+
+    before(function () {
+      nativeExit = process.exit;
+      process.exit = function () {
+        exitCalledWith = [].slice.call(arguments);
+      };
+    });
+
+    after(function () {
+      process.exit = nativeExit;
+    });
+
+    it('logs and exits with status code 1', function () {
+      args(
+        ['--url', 'https://localhost:8080/test.html', '--https-server', '4040']
+      );
+      assert.deepStrictEqual(exitCalledWith, [1]);
+    });
   });
 
   it('parses --wd-file', function () {
@@ -283,6 +300,7 @@ describe('args', function () {
     var noValueOpts = args(['--https-server']);
     assert.strictEqual(noValueOpts['https-server'], 0);
   });
+
 
   it('parses --allow-chrome-as-root', function () {
     var opts = args(['--allow-chrome-as-root']);

--- a/test/chromium-test.js
+++ b/test/chromium-test.js
@@ -158,7 +158,7 @@ describe('chromium', function () {
     run('url', ['-R', 'tap', '--url', url], function (code, stdout) {
       assert.equal(stdout, '# chromium:\n'
         + '1..1\n'
-        + 'location.href = file://' + __dirname + '/fixture/url/test.html\n'
+        + 'location.href = ' + url + '\n'
         + 'ok 1 url has H1 element\n'
         + '# tests 1\n'
         + '# pass 1\n'
@@ -168,7 +168,7 @@ describe('chromium', function () {
     });
   });
 
-  it('runs tests in the context of a localhost https server with specified URL',
+  it('runs tests in the context of a localhost https server with URL and port',
     function (done) {
       var url = 'https://localhost:8080/test.html';
       run('url', ['-R', 'tap', '--https-server', '8080', '--url', url],
@@ -185,7 +185,24 @@ describe('chromium', function () {
         });
     });
 
-  it('runs tests in the context of a localhost https server with default URL',
+  it('runs tests in the context of a localhost https server with URL only',
+    function (done) {
+      var url = 'https://localhost:7070/test.html';
+      run('url', ['-R', 'tap', '--url', url],
+        function (code, stdout) {
+          assert.equal(stdout, '# chromium:\n'
+            + '1..1\n'
+            + 'location.href = ' + url + '\n'
+            + 'ok 1 url has H1 element\n'
+            + '# tests 1\n'
+            + '# pass 1\n'
+            + '# fail 0\n');
+          assert.equal(code, 0);
+          done();
+        });
+    });
+
+  it('runs tests in the context of a localhost https server with port only',
     function (done) {
       run('url', ['-R', 'tap', '--https-server', '8080'],
         function (code, stdout) {
@@ -214,8 +231,38 @@ describe('chromium', function () {
             /^# chromium:$/,
             /^1\.\.1$/,
             /^location\.protocol = https:$/,
+            /^location\.hostname = localhost$/,
             /^location\.port = \d{1,5}$/,
-            /^ok 1 port passes after printing protocol and port$/,
+            /^location\.pathname = \//,
+            /^ok 1 port passes after printing location info$/,
+            /^# tests 1$/,
+            /^# pass 1$/,
+            /^# fail 0$/
+          ];
+          expected.forEach(function (re, index) {
+            assert(
+              re.test(lines[index]),
+              'Unexpected line ' + index + ': ' + lines[index]
+            );
+          });
+          done();
+        });
+    });
+
+  it('runs tests in the context of a localhost https server with naked url',
+    function (done) {
+      run('port', ['-R', 'tap', '--url', 'https://localhost/index.html'],
+        function (code, stdout) {
+          assert.equal(code, 0);
+          var lines = stdout.split('\n');
+          var expected = [
+            /^# chromium:$/,
+            /^1\.\.1$/,
+            /^location\.protocol = https:$/,
+            /^location\.hostname = localhost$/,
+            /^location\.port = \d{1,5}$/,
+            /^location\.pathname = \/index.html$/,
+            /^ok 1 port passes after printing location info$/,
             /^# tests 1$/,
             /^# pass 1$/,
             /^# fail 0$/

--- a/test/fixture/port/test/port.js
+++ b/test/fixture/port/test/port.js
@@ -4,9 +4,11 @@
 var assert = require('assert');
 
 describe('port', function () {
-  it('passes after printing protocol and port', function () {
+  it('passes after printing location info', function () {
     console.log('location.protocol = ' + location.protocol);
+    console.log('location.hostname = ' + location.hostname);
     console.log('location.port = ' + location.port);
+    console.log('location.pathname = ' + location.pathname);
     assert(true);
   });
 });


### PR DESCRIPTION
When --url is given, the port to be used by the local https server can be derived in case the --https-server arg is empty.

This is part 2 of #164.