### PR TITLE
Document async polling arg in readme and help text

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ break at the `debugger` statement.
 - `--yields` or `-y` changes the yield interval to allow pending I/O to happen.
 - `--version` or `-v` shows the Mochify version number.
 - `--help` or `-h` shows usage and all available options.
+- `--async-polling` disables async polling when set to false (for use in Appium).
 
 ## SauceLabs setup
 

--- a/lib/help.txt
+++ b/lib/help.txt
@@ -94,3 +94,6 @@ Defaults "entry" to "./test/*.js".
          -v, --version  Print mochify version and exit.
 
             -h, --help  Show this message and exit.
+
+       --async-polling  If false, async polling will be disabled
+                        (use when running in Appium). Defaults to true.


### PR DESCRIPTION
Looks like this is not fully documented yet.