### PR TITLE
Filter out non-log messages when reading console

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,4 @@ language: node_js
 node_js:
   - "6"
   - "8"
+  - "10"

--- a/lib/chromium.js
+++ b/lib/chromium.js
@@ -98,6 +98,9 @@ module.exports = function (b, opts) {
 
       var consumer;
       page.on('console', function (msg) {
+        if (msg.type() !== 'log') {
+          return;
+        }
         var text = msg.text();
         if (text.indexOf('[EXIT ') === 0) {
           var code = text.substring(6, text.length - 1);

--- a/lib/chromium.js
+++ b/lib/chromium.js
@@ -98,10 +98,12 @@ module.exports = function (b, opts) {
 
       var consumer;
       page.on('console', function (msg) {
+        var text = msg.text();
         if (msg.type() !== 'log') {
+          process.stderr.write(text);
+          process.stderr.write('\n');
           return;
         }
-        var text = msg.text();
         if (text.indexOf('[EXIT ') === 0) {
           var code = text.substring(6, text.length - 1);
           if (code !== '0') {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1060,6 +1060,7 @@
     },
     "escape-string-regexp": {
       "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "escope": {
@@ -2693,9 +2694,9 @@
       }
     },
     "mime": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.3.1.tgz",
+      "integrity": "sha512-OEUllcVoydBHGN1z84yfQDimn58pZNNNXgZlHXSboxMlFvgI6MXSWpWKpFRra7H1HxpVhHTkrghfRW49k6yjeg=="
     },
     "min-wd": {
       "version": "2.10.0",
@@ -3201,45 +3202,26 @@
       "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
     },
     "puppeteer": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-1.3.0.tgz",
-      "integrity": "sha512-wx10aPQPpGJVxdB6yoDSLm9p4rCwARUSLMVV0bx++owuqkvviXKyiFM3EWsywaFmjOKNPXacIjplF7xhHiFP3w==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-1.4.0.tgz",
+      "integrity": "sha512-WDnC1FSHTedvRSS8BZB73tPAx2svUCWFdcxVjrybw8pbKOAB1v5S/pW0EamkqQoL1mXiBc+v8lyYjhhzMHIk1Q==",
       "requires": {
-        "debug": "^2.6.8",
+        "debug": "^3.1.0",
         "extract-zip": "^1.6.5",
         "https-proxy-agent": "^2.1.0",
-        "mime": "^1.3.4",
+        "mime": "^2.0.3",
         "progress": "^2.0.0",
         "proxy-from-env": "^1.0.0",
         "rimraf": "^2.6.1",
         "ws": "^3.0.0"
       },
       "dependencies": {
-        "agent-base": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.0.tgz",
-          "integrity": "sha512-c+R/U5X+2zz2+UCrCFv6odQzJdoqI+YecuhnAJLa1zYaMc13zPfwMwZrr91Pd1DYNo/yPRbiM4WVf9whgwFsIg==",
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
           "requires": {
-            "es6-promisify": "^5.0.0"
-          }
-        },
-        "https-proxy-agent": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
-          "integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
-          "requires": {
-            "agent-base": "^4.1.0",
-            "debug": "^3.1.0"
-          },
-          "dependencies": {
-            "debug": {
-              "version": "3.1.0",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-              "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-              "requires": {
-                "ms": "2.0.0"
-              }
-            }
+            "ms": "2.0.0"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "min-wd": "^2.10.0",
     "mocaccino": "^3.0.0",
     "mocha": "^4.1.0",
-    "puppeteer": "^1.0.0",
+    "puppeteer": "^1.4.0",
     "resolve": "^1.5.0",
     "source-mapper": "^2.0.0",
     "subarg": "^1.0.0",

--- a/test/args-test.js
+++ b/test/args-test.js
@@ -344,34 +344,35 @@ describe('args', function () {
   });
 
   it('requires single glob to match', function (done) {
-    run('passes', ['./unknown/*'], function (code, stdout) {
+    run('passes', ['./unknown/*'], function (code, stdout, stderr) {
       assert.equal(code, 1);
-      assert.equal(stdout, 'Error: Nothing found for "./unknown/*".\n\n');
+      assert.equal(stderr, 'Error: Nothing found for "./unknown/*".\n\n');
       done();
     });
   });
 
   it('requires multiple globs to match', function (done) {
-    run('passes', ['./thing-a/*', './thing-b/*'], function (code, stdout) {
-      assert.equal(code, 1);
-      assert.equal(stdout,
-          'Error: Nothing found for "./thing-a/*" or "./thing-b/*".\n\n');
-      done();
-    });
+    run('passes', ['./thing-a/*', './thing-b/*'],
+      function (code, stdout, stderr) {
+        assert.equal(code, 1);
+        assert.equal(stderr,
+            'Error: Nothing found for "./thing-a/*" or "./thing-b/*".\n\n');
+        done();
+      });
   });
 
   it('fails with meaningful message if file is missing', function (done) {
-    run('passes', ['./unknown-file.js'], function (code, stdout) {
+    run('passes', ['./unknown-file.js'], function (code, stdout, stderr) {
       assert.notEqual(code, 0);
-      assert(stdout.indexOf('/unknown-file.js') !== -1);
+      assert(stderr.indexOf('/unknown-file.js') !== -1);
       done();
     });
   });
 
   it('fails with meaningful message for defaults', function (done) {
-    run('.', [], function (code, stdout) {
+    run('.', [], function (code, stdout, stderr) {
       assert.equal(code, 1);
-      assert.equal(stdout, 'Error: Nothing found for "./test/*.js".\n\n');
+      assert.equal(stderr, 'Error: Nothing found for "./test/*.js".\n\n');
       done();
     });
   });

--- a/test/fixture/console/test/console.js
+++ b/test/fixture/console/test/console.js
@@ -1,0 +1,22 @@
+/*global describe, it*/
+'use strict';
+
+describe('console', function () {
+
+  it('log', function () {
+    console.log('log');
+  });
+
+  it('info', function () {
+    console.info('info');
+  });
+
+  it('warn', function () {
+    console.log('warn');
+  });
+
+  it('error', function () {
+    console.error('error');
+  });
+
+});

--- a/test/fixture/run.js
+++ b/test/fixture/run.js
@@ -19,14 +19,15 @@ function run(test, args, callback) {
   });
 
   var stdout = '';
-  var handle = function (data) {
+  mochify.stdout.on('data', function (data) {
     stdout += data;
-  };
-  mochify.stdout.on('data', handle);
-  mochify.stderr.on('data', handle);
-
+  });
+  var stderr = '';
+  mochify.stderr.on('data', function (data) {
+    stderr += data;
+  });
   mochify.on('close', function (code) {
-    callback(code, stdout);
+    callback(code, stdout, stderr);
   });
 }
 

--- a/test/node-test.js
+++ b/test/node-test.js
@@ -41,25 +41,27 @@ describe('node', function () {
   });
 
   it('coverage tap', function (done) {
-    run('passes', ['--node', '--cover', '-R', 'tap'], function (code, stdout) {
-      assert.equal(stdout, '# node:\n'
-        + '1..1\n'
-        + 'ok 1 test passes\n'
-        + '# tests 1\n'
-        + '# pass 1\n'
-        + '# fail 0\n# coverage: 8/8 (100.00 %)\n\n');
-      assert.equal(code, 0);
-      done();
-    });
+    run('passes', ['--node', '--cover', '-R', 'tap'],
+      function (code, stdout, stderr) {
+        assert.equal(stdout, '# node:\n'
+          + '1..1\n'
+          + 'ok 1 test passes\n'
+          + '# tests 1\n'
+          + '# pass 1\n'
+          + '# fail 0\n');
+        assert.equal(stderr, '# coverage: 8/8 (100.00 %)\n\n');
+        assert.equal(code, 0);
+        done();
+      });
   });
 
   it('coverage dot', function (done) {
     run('passes', ['--node', '--cover', '--no-colors', '-R', 'dot'],
-      function (code, stdout) {
+      function (code, stdout, stderr) {
         var lines = stdout.trim().split(/\n+/);
         assert.equal(lines[0], '# node:');
         assert.equal(lines[1], '  .');
-        assert.equal(lines[3], '# coverage: 8/8 (100.00 %)');
+        assert.equal(stderr, '# coverage: 8/8 (100.00 %)\n\n');
         assert.equal(code, 0);
         done();
       });
@@ -74,16 +76,15 @@ describe('node', function () {
 
   it('fails cover', function (done) {
     run('fails-cover', ['--node', '--cover', '-R', 'tap'],
-      function (code, stdout) {
-        var testOut = '# node:\n'
+      function (code, stdout, stderr) {
+        assert.equal(stdout, '# node:\n'
           + '1..1\n'
           + 'ok 1 test does not cover\n'
           + '# tests 1\n'
           + '# pass 1\n'
-          + '# fail 0\n';
+          + '# fail 0\n');
         var coverOut = '\n# coverage: 9/10 (90.00 %)\n\nError: Exit 1\n\n';
-        assert.equal(stdout.substring(0, testOut.length), testOut);
-        assert.equal(stdout.substring(stdout.length - coverOut.length),
+        assert.equal(stderr.substring(stderr.length - coverOut.length),
             coverOut);
         assert.equal(code, 1);
         done();
@@ -286,8 +287,8 @@ describe('node', function () {
       });
   });
 
-  // This test case fails on node 0.10 only. The corresponding phantomjs test
-  // passes on node 0.10 and 0.12.
+  // This test case passes on node 6 but fails on node 8 and 10. The
+  // corresponding chromium test also passes.
   it.skip('shows unicode diff', function (done) {
     run('unicode', ['--node', '-R', 'tap'], function (code, stdout) {
       assert.equal(stdout.indexOf('# node:\n'
@@ -301,9 +302,9 @@ describe('node', function () {
 
   it('fails external', function (done) {
     run('external', ['--node', '-R', 'tap'],
-      function (code, stdout) {
+      function (code, stdout, stderr) {
         assert.equal(
-          stdout.indexOf('Error: Cannot find module \'unresolvable\''),
+          stderr.indexOf('Error: Cannot find module \'unresolvable\''),
           0);
         assert.equal(code, 1);
         done();


### PR DESCRIPTION
Puppeteer >= 1.4.0 introduced changes that will change the
way messages are passed to `console` events. To filter out
non-test related messages, filter all non-log messages. Also
bump puppeteer to ^1.4.0 and start testing in Node 10.

So this is fixing #171 - looks like we got bitten by: https://github.com/GoogleChrome/puppeteer/pull/2400 which changes what kind of messages will trigger a `console` event.