### PR TITLE
Update min-wd to 2.11.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ the test framework.
 - Run tests in real browsers
     - Supports [SauceLabs][] ([docs](#saucelabs-setup))
     - Supports [Appium][] ([docs](#appium-setup))
+    - Supports [BrowserStack][] ([docs](#browserstack-setup))
     - Supports [WebDriver][] ([docs](#selenium-webdriver-setup))
 - Code coverage options:
     - Using [istanbul][] ([docs](#code-coverage-with-istanbul))
@@ -179,6 +180,24 @@ That's it! Now `mochify --wd` will run your Mocha test cases in the configured
 browsers simultaneously. If you installed mochify without `-g`, you will have
 to run `node_modules/.bin/mochify --wd`.
 
+Additional Selenium capabilities and browser-specific capabilities can be
+specified with the `capabilities` property:
+
+```json
+{
+  "hostname": "localhost",
+  "port": 4444,
+  "browsers": [{
+    "name": "chrome",
+    "capabilities": {
+      "chromeOptions": {
+        "args": ["--headless", "--disable-gpu"]
+      }
+    }
+  }]
+}
+```
+
 ## SauceLabs setup
 
 Export your [SauceLabs][] credentials:
@@ -231,6 +250,32 @@ Setup for iOS Simulator on Mac OS X (requires XCode):
 
 It's important to use `--async-polling false` here. The default asynchronous
 polling does not work with this setup.
+
+## BrowserStack setup
+
+Export your [BrowserStack][] credentials:
+
+```bash
+export BROWSERSTACK_USERNAME="your-user-name"
+export BROWSERSTACK_ACCESS_KEY="your-access-key"
+```
+
+Example `.min-wd` file:
+
+```js
+module.exports = {
+  "hostname": "hub-cloud.browserstack.com",
+  "port": 80,
+  "browsers": [{
+    "name": "chrome",
+    "capabilities": {
+      "browser": "Chrome",
+      "browserstack.user": process.env.BROWSERSTACK_USERNAME,
+      "browserstack.key": process.env.BROWSERSTACK_ACCESS_KEY
+    }
+  }]
+}
+```
 
 ## Reporters
 
@@ -367,6 +412,7 @@ MIT
 [min-webdriver]: https://github.com/mantoni/min-webdriver
 [SauceLabs]: https://saucelabs.com
 [Appium]: http://appium.io
+[BrowserStack]: https://www.browserstack.com
 [Mocha test runner]: https://github.com/mantoni/mocaccino.js
 [consolify]: https://github.com/mantoni/consolify
 [subargs]: https://github.com/substack/subarg

--- a/package-lock.json
+++ b/package-lock.json
@@ -2699,9 +2699,9 @@
       "integrity": "sha512-OEUllcVoydBHGN1z84yfQDimn58pZNNNXgZlHXSboxMlFvgI6MXSWpWKpFRra7H1HxpVhHTkrghfRW49k6yjeg=="
     },
     "min-wd": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/min-wd/-/min-wd-2.10.0.tgz",
-      "integrity": "sha512-+eoO01N6vZV0SYwiXS4RbNvPEdHwzSEW1voqepxN7yMrvRzQSHJ3ojHvihSwKgV2nZIDuLNFP07JJhbuzm23uw==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/min-wd/-/min-wd-2.11.0.tgz",
+      "integrity": "sha512-nZec9Z7vgUChr7rMsaCzlRMLFOKgAlEKmTmfw7MXS+rNmN6OVfdgDts6A4AOM+MxJRYkneIyBc6IjObPXvp3ng==",
       "requires": {
         "brout": "^1.1.0",
         "listen": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "consolify": "^2.1.0",
     "coverify": "^1.4.1",
     "glob": "^7.1.2",
-    "min-wd": "^2.10.0",
+    "min-wd": "^2.11.0",
     "mocaccino": "^3.0.0",
     "mocha": "^4.1.0",
     "puppeteer": "^1.4.0",


### PR DESCRIPTION
Allows mochify to take advantage of custom capabilities, which lets us specify browser options, set up BrowserStack integration, etc.

Would you like me to add some more helpful documentation to make people aware of the new features in min-wd? Do we need tests?