### PR TITLE
 Ensure browserify plugins are always mounted in the same order

### DIFF
--- a/lib/mochify.js
+++ b/lib/mochify.js
@@ -162,6 +162,10 @@ module.exports = function (_, opts) {
       next();
     } else if (opts.node) {
       b.plugin(node, opts);
+      // As opposed to when using the chromium / webdriver plugins
+      // `next` needs to be called synchronously when using the node
+      // plugin as otherwise it would exit prematurely.
+      // This should be fixed so it can be used in line with the other cases.
       next();
     } else if (opts.wd) {
       withServer(b, opts, function () {

--- a/lib/mochify.js
+++ b/lib/mochify.js
@@ -41,7 +41,9 @@ function withServer(b, opts, callback) {
       callback();
     });
   } else {
-    callback();
+    // ensure the callback is always called asynchronously, no matter
+    // if a server is created or not
+    process.nextTick(callback);
   }
 }
 
@@ -154,49 +156,58 @@ module.exports = function (_, opts) {
     noColors        : opts.noColors
   };
 
+  (function initPlugins(next) {
+    if (opts.consolify) {
+      b.plugin(consolify, opts);
+      next();
+    } else if (opts.node) {
+      b.plugin(node, opts);
+      next();
+    } else if (opts.wd) {
+      withServer(b, opts, function () {
+        var wdOpts = {
+          asyncPolling: opts['async-polling']
+        };
+        if (opts.url) {
+          wdOpts.url = opts.url;
+        }
+        if (opts['wd-file']) {
+          wdOpts.wdFile = opts['wd-file'];
+        }
+        b.plugin(webdriver, wdOpts);
+        b.pipeline.get('wrap').push(trace());
+        next();
+      });
+    } else {
+      withServer(b, opts, function () {
+        b.plugin(chromium, opts);
+        next();
+      });
+    }
 
-  if (opts.consolify) {
-    b.plugin(consolify, opts);
-  } else if (opts.node) {
-    b.plugin(node, opts);
-  } else if (opts.wd) {
-    withServer(b, opts, function () {
-      var wdOpts = {
-        asyncPolling: opts['async-polling']
-      };
-      if (opts.url) {
-        wdOpts.url = opts.url;
-      }
-      if (opts['wd-file']) {
-        wdOpts.wdFile = opts['wd-file'];
-      }
-      b.plugin(webdriver, wdOpts);
-      b.pipeline.get('wrap').push(trace());
-    });
-  } else {
-    withServer(b, opts, function () {
-      b.plugin(chromium, opts);
-    });
-  }
+    b.plugin(mocaccino, mocaccinoOpts);
+  }(function appendAdditionalPlugins() {
+    if (opts.plugin) {
+      [].concat(opts.plugin).forEach(function (p) {
+        if (typeof p === 'string') {
+          b.plugin(p, {});
+        } else {
+          b.plugin(p._.shift(), p);
+        }
+      });
+    }
+    if (opts.cover) {
+      b.plugin(cover);
+    }
+  }));
 
   entries.forEach(function (entry) {
     b.add(entry);
   });
 
-  b.plugin(mocaccino, mocaccinoOpts);
-
   if (opts.external) {
     [].concat(opts.external).forEach(function (x) {
       b.external(x);
-    });
-  }
-  if (opts.plugin) {
-    [].concat(opts.plugin).forEach(function (p) {
-      if (typeof p === 'string') {
-        b.plugin(p, {});
-      } else {
-        b.plugin(p._.shift(), p);
-      }
     });
   }
   if (opts.transform) {
@@ -227,10 +238,8 @@ module.exports = function (_, opts) {
       });
     });
   }
-
   if (opts.cover) {
     b.transform(coverify);
-    b.plugin(cover);
   }
 
   b.on('error', error);

--- a/test/chromium-test.js
+++ b/test/chromium-test.js
@@ -138,6 +138,70 @@ describe('chromium', function () {
     });
   });
 
+  it('passes transform to browserify', function (done) {
+    run('passes', ['--node', '-R', 'tap', '--transform', '../transform.js'],
+      function (code, stdout) {
+        var lines = stdout.split('\n');
+        assert.equal(lines[0], 'passes/test/passes.js');
+        assert.equal(code, 0);
+        done();
+      });
+  });
+
+  it('passes transform with options to browserify', function (done) {
+    run('passes', ['--node', '-R', 'tap', '--transform', '[',
+      '../transform.js', '-x', ']'], function (code, stdout) {
+        var lines = stdout.split('\n');
+        assert(JSON.parse(lines[1]).x);
+        assert.equal(code, 0);
+        done();
+      });
+  });
+
+  it('passes multiple transforms to browserify', function (done) {
+    run('passes', ['--node', '-R', 'tap', '--transform',
+      '../transform.js', '--transform',
+      '../transform.js'], function (code, stdout) {
+        var lines = stdout.split('\n');
+        assert.equal(lines[0], 'passes/test/passes.js');
+        assert.equal(lines[2], 'passes/test/passes.js');
+        assert.equal(code, 0);
+        done();
+      });
+  });
+
+  it('passes plugin to browserify', function (done) {
+    run('passes', ['--node', '-R', 'tap', '--plugin',
+      '../plugin.js'], function (code, stdout) {
+        var lines = stdout.split('\n');
+        assert.equal(lines[0], 'passes/test/passes.js');
+        assert.equal(code, 0);
+        done();
+      });
+  });
+
+  it('passes plugin with options to browserify', function (done) {
+    run('passes', ['--node', '-R', 'tap', '--plugin', '[',
+      '../plugin.js', '-x', ']'], function (code, stdout) {
+        var lines = stdout.split('\n');
+        assert(JSON.parse(lines[1]).x);
+        assert.equal(code, 0);
+        done();
+      });
+  });
+
+  it('passes multiple plugins to browserify', function (done) {
+    run('passes', ['--node', '-R', 'tap', '--plugin', '../plugin.js',
+      '--plugin', '../plugin.js'], function (code, stdout) {
+        var lines = stdout.split('\n');
+        assert.equal(lines[0], 'passes/test/passes.js');
+        assert.equal(lines[2], 'passes/test/passes.js');
+        assert.equal(code, 0);
+        done();
+      });
+  });
+
+
   it('shows unicode diff', function (done) {
     run('unicode', ['-R', 'tap'], function (code, stdout) {
       assert.equal(stdout.indexOf('# chromium:\n'

--- a/test/chromium-test.js
+++ b/test/chromium-test.js
@@ -139,7 +139,7 @@ describe('chromium', function () {
   });
 
   it('passes transform to browserify', function (done) {
-    run('passes', ['--node', '-R', 'tap', '--transform', '../transform.js'],
+    run('passes', ['-R', 'tap', '--transform', '../transform.js'],
       function (code, stdout) {
         var lines = stdout.split('\n');
         assert.equal(lines[0], 'passes/test/passes.js');
@@ -149,7 +149,7 @@ describe('chromium', function () {
   });
 
   it('passes transform with options to browserify', function (done) {
-    run('passes', ['--node', '-R', 'tap', '--transform', '[',
+    run('passes', ['-R', 'tap', '--transform', '[',
       '../transform.js', '-x', ']'], function (code, stdout) {
         var lines = stdout.split('\n');
         assert(JSON.parse(lines[1]).x);
@@ -159,7 +159,7 @@ describe('chromium', function () {
   });
 
   it('passes multiple transforms to browserify', function (done) {
-    run('passes', ['--node', '-R', 'tap', '--transform',
+    run('passes', ['-R', 'tap', '--transform',
       '../transform.js', '--transform',
       '../transform.js'], function (code, stdout) {
         var lines = stdout.split('\n');
@@ -171,7 +171,7 @@ describe('chromium', function () {
   });
 
   it('passes plugin to browserify', function (done) {
-    run('passes', ['--node', '-R', 'tap', '--plugin',
+    run('passes', ['-R', 'tap', '--plugin',
       '../plugin.js'], function (code, stdout) {
         var lines = stdout.split('\n');
         assert.equal(lines[0], 'passes/test/passes.js');
@@ -181,7 +181,7 @@ describe('chromium', function () {
   });
 
   it('passes plugin with options to browserify', function (done) {
-    run('passes', ['--node', '-R', 'tap', '--plugin', '[',
+    run('passes', ['-R', 'tap', '--plugin', '[',
       '../plugin.js', '-x', ']'], function (code, stdout) {
         var lines = stdout.split('\n');
         assert(JSON.parse(lines[1]).x);
@@ -191,7 +191,7 @@ describe('chromium', function () {
   });
 
   it('passes multiple plugins to browserify', function (done) {
-    run('passes', ['--node', '-R', 'tap', '--plugin', '../plugin.js',
+    run('passes', ['-R', 'tap', '--plugin', '../plugin.js',
       '--plugin', '../plugin.js'], function (code, stdout) {
         var lines = stdout.split('\n');
         assert.equal(lines[0], 'passes/test/passes.js');


### PR DESCRIPTION
This is an attempt at fixing #177.

Tests and all seem to pass and it also fixes the issue in the example repo provided in the issue, then again I am slightly worried if it is even a good idea to potentially add browserify plugins asynchronously or if this needs some bigger refactoring in order to do everything synchronously always.