### PR TITLE
Do not add plugins on browserify object asynchronously to ensure predictable order

### DIFF
--- a/lib/mochify.js
+++ b/lib/mochify.js
@@ -24,26 +24,9 @@ var trace      = require('./trace');
 var args       = require('./args');
 var server     = require('./server');
 
-function withServer(b, opts, callback) {
-  var serverPort = opts['https-server'];
-  if (Number.isInteger(serverPort)) {
-    server(b, serverPort, opts.watch, function (err, actualPort) {
-      if (err) {
-        console.error('Error: Failed to launch server\n' + err.stack + '\n');
-        process.exit(1);
-      }
-      if (!opts.url) {
-        opts.url = url.parse('https://localhost:' + actualPort);
-      } else {
-        opts.url.port = actualPort;
-      }
-      opts.url = url.format(opts.url);
-      callback();
-    });
-  } else {
-    // ensure the callback is always called asynchronously, no matter
-    // if a server is created or not
-    process.nextTick(callback);
+function withServer(opts, callback) {
+  if (Number.isInteger(opts['https-server'])) {
+    server(opts['https-server'], callback);
   }
 }
 
@@ -166,54 +149,63 @@ module.exports = function (_, opts) {
     noColors        : opts.noColors
   };
 
-  (function initPlugins(next) {
-    if (opts.consolify) {
-      b.plugin(consolify, opts);
-      next();
-    } else if (opts.node) {
-      b.plugin(node, opts);
-      // As opposed to when using the chromium / webdriver plugins
-      // `next` needs to be called synchronously when using the node
-      // plugin as otherwise it would exit prematurely.
-      // This should be fixed so it can be used in line with the other cases.
-      next();
-    } else if (opts.wd) {
-      withServer(b, opts, function () {
-        var wdOpts = {
-          asyncPolling: opts['async-polling']
-        };
-        if (opts.url) {
-          wdOpts.url = opts.url;
-        }
-        if (opts['wd-file']) {
-          wdOpts.wdFile = opts['wd-file'];
-        }
-        b.plugin(webdriver, wdOpts);
-        b.pipeline.get('wrap').push(trace());
-        next();
-      });
-    } else {
-      withServer(b, opts, function () {
-        b.plugin(chromium, opts);
-        next();
+  function serverReady(err, port, onError, handleEnd) {
+    if (err) {
+      console.error('Error: Failed to launch server\n' + err.stack + '\n');
+      process.exit(1);
+    }
+
+    onError(function (err) {
+      b.emit('error', err);
+    });
+
+    if (!opts.watch) {
+      b.pipeline.get('wrap').on('end', function () {
+        handleEnd();
       });
     }
 
-    b.plugin(mocaccino, mocaccinoOpts);
-  }(function appendAdditionalPlugins() {
-    if (opts.plugin) {
-      [].concat(opts.plugin).forEach(function (p) {
-        if (typeof p === 'string') {
-          b.plugin(p, {});
-        } else {
-          b.plugin(p._.shift(), p);
-        }
-      });
+    if (!opts.url) {
+      opts.url = url.parse('https://localhost:' + port);
+    } else {
+      opts.url.port = port;
     }
-    if (opts.cover) {
-      b.plugin(cover);
+    opts.url = url.format(opts.url);
+  }
+
+  if (opts.consolify) {
+    b.plugin(consolify, opts);
+  } else if (opts.node) {
+    b.plugin(node, opts);
+  } else if (opts.wd) {
+    var wdOpts = {
+      asyncPolling: opts['async-polling']
+    };
+    if (opts.url) {
+      wdOpts.url = opts.url;
     }
-  }));
+    if (opts['wd-file']) {
+      wdOpts.wdFile = opts['wd-file'];
+    }
+    b.plugin(webdriver, wdOpts);
+    b.pipeline.get('wrap').push(trace());
+    withServer(opts, serverReady);
+  } else {
+    b.plugin(chromium, opts);
+    withServer(opts, serverReady);
+  }
+
+  b.plugin(mocaccino, mocaccinoOpts);
+
+  if (opts.plugin) {
+    [].concat(opts.plugin).forEach(function (p) {
+      if (typeof p === 'string') {
+        b.plugin(p, {});
+      } else {
+        b.plugin(p._.shift(), p);
+      }
+    });
+  }
 
   entries.forEach(function (entry) {
     b.add(entry);
@@ -254,6 +246,7 @@ module.exports = function (_, opts) {
   }
   if (opts.cover) {
     b.transform(coverify);
+    b.plugin(cover);
   }
 
   b.on('error', error);

--- a/lib/server.js
+++ b/lib/server.js
@@ -4,7 +4,7 @@ var fs = require('fs');
 var path = require('path');
 var https = require('https');
 
-module.exports = function (b, port, watch, callback) {
+module.exports = function (port, callback) {
   var server = https.createServer({
     key: fs.readFileSync(path.join(__dirname, '..', 'fixture', 'key.pem')),
     cert: fs.readFileSync(path.join(__dirname, '..', 'fixture', 'cert.pem')),
@@ -26,17 +26,26 @@ module.exports = function (b, port, watch, callback) {
     }
   });
 
-  server.on('error', function (err) {
-    b.emit('error', err);
-  });
-
-  server.listen(port, function (err) {
-    callback(err, server.address().port);
-  });
-
-  if (!watch) {
-    b.pipeline.get('wrap').on('end', function () {
-      server.close();
-    });
+  function onError(errListener) {
+    server.on('error', errListener);
   }
+
+  function close() {
+    server.close();
+  }
+
+  server.on('error', function (err) {
+    if (callback.called) {
+      return;
+    }
+    callback(err, null, onError, close);
+    callback.called = true;
+  });
+  server.listen(port, function (err) {
+    if (callback.called) {
+      return;
+    }
+    callback(err, server.address().port, onError, close);
+    callback.called = true;
+  });
 };


### PR DESCRIPTION
I looked into the `node` plugin issue from #178 which led nowhere and gave me a terrible headache :pill:. I feel browserify does not really expect plugins and transforms to be "maybe" added asynchronously, at least I wasn't able to find any logic in what was called in which order if plugins were added like this.

Instead I moved all the main action on `b` back into the synchronous `mochify` call, so it's 100% foolproof that the calls will be executed in the supposed order.

The server will still be created asynchronously, which means we rely on puppeteer to wait for it to be ready, but that's what's happening at the moment as well and is the price for not deferring `bundle()` until setup has happened.

I feel this is quite a bit saner than #178, but maybe there's other input as well.