### PR TITLE
Consolidate validation of options in one place

### DIFF
--- a/lib/args.js
+++ b/lib/args.js
@@ -77,17 +77,6 @@ function args(argv) {
   if (opts.hasOwnProperty('url')) {
     opts.url = url.parse(opts.url);
     delete opts.url.host;
-
-    if (opts.hasOwnProperty('https-server')) {
-      if (opts['https-server'] !== opts.url.port) {
-        console.log(
-          'The port values in --https-server and --url did not match,'
-          + ' got "' + opts['https-server'] + '" and "' + opts.url.port + '".\n'
-          + 'You should be able to use the --url option only.'
-        );
-        process.exit(1);
-      }
-    }
   }
 
   if (opts.hasOwnProperty('https-server')) {

--- a/lib/mochify.js
+++ b/lib/mochify.js
@@ -105,6 +105,16 @@ module.exports = function (_, opts) {
     process.exit(1);
   }
 
+  if (opts['https-server'] && opts.url
+      && String(opts['https-server']) !== opts.url.port) {
+    console.log(
+      'The port values in --https-server and --url did not match,'
+      + ' got "' + opts['https-server'] + '" and "' + opts.url.port + '".\n'
+      + 'You should be able to use the --url option only.'
+    );
+    process.exit(1);
+  }
+
   var entries = [];
   var globs = _.split(' ');
   globs.forEach(function (arg) {

--- a/test/args-test.js
+++ b/test/args-test.js
@@ -99,29 +99,6 @@ describe('args', function () {
     assert.equal(opts['https-server'], 8080);
   });
 
-  context('with conflicting values given', function () {
-    var nativeExit;
-    var exitCalledWith;
-
-    before(function () {
-      nativeExit = process.exit;
-      process.exit = function () {
-        exitCalledWith = [].slice.call(arguments);
-      };
-    });
-
-    after(function () {
-      process.exit = nativeExit;
-    });
-
-    it('logs and exits with status code 1', function () {
-      args(
-        ['--url', 'https://localhost:8080/test.html', '--https-server', '4040']
-      );
-      assert.deepStrictEqual(exitCalledWith, [1]);
-    });
-  });
-
   it('parses --wd-file', function () {
     var opts = args(['--wd-file', '.min-wd-other']);
 
@@ -385,4 +362,14 @@ describe('args', function () {
     });
   });
 
+  it('fails with meaningful message when given conflicting port values',
+    function (done) {
+      run('passes', ['--url', 'https://localhost:8080/test.html',
+        '--https-server', '4040'],
+        function (code, stdout) {
+          assert.strictEqual(code, 1);
+          assert(stdout.indexOf('got "4040" and "8080"') !== -1);
+          done();
+        });
+    });
 });


### PR DESCRIPTION
When looking at #180 I noticed that the validation of the server port was done in the `args` module, when everything else would be validated in `mochify`. This simply moves things to the same location.