### PR TITLE
Display build status from master in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > TDD with Browserify, Mocha, Headless Chrome and WebDriver
 
-[![Build Status]](https://travis-ci.org/mantoni/mochify.js)
+[![Build Status](https://travis-ci.org/mantoni/mochify.js.svg?branch=master)](https://travis-ci.org/mantoni/mochify.js)
 [![SemVer]](http://semver.org)
 [![License]](https://github.com/mantoni/mochify.js/blob/master/LICENSE)
 


### PR DESCRIPTION
I think this is what caused the confusion about the build status in #180 

`master` is all green at the moment: https://travis-ci.org/mantoni/mochify.js/branches