### PR TITLE
Upgrade Mocaccino to v4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2803,68 +2803,33 @@
       }
     },
     "mocaccino": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/mocaccino/-/mocaccino-3.0.0.tgz",
-      "integrity": "sha512-mc0xkHFGxnW4B49la2LG8qaHBIiLArqG9zkgP+byp/kmWby1/Bi8CIpwBKANu91SkZ/c4Qk+0JnYM5u1PXEQYw==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mocaccino/-/mocaccino-4.0.0.tgz",
+      "integrity": "sha512-FViWtcfdCe2qTDLoLHTM0DFseL3H/AuZFi3rzcaFjAJR7K7LvH7x3R9XQR7i26x48znSKzhjkyrSWHh4z8JpbA==",
       "requires": {
         "brout": "^1.1.0",
         "listen": "^1.0.0",
-        "mocha": "^4.0.1",
-        "resolve": "^1.1.6",
-        "supports-color": "^3.1.2",
-        "through2": "^2.0.0"
+        "mocha": "^5.2.0",
+        "resolve": "^1.8.1",
+        "supports-color": "^5.5.0",
+        "through2": "^2.0.5"
       },
       "dependencies": {
-        "browser-stdout": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
-          "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8="
-        },
-        "commander": {
-          "version": "2.11.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-          "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ=="
-        },
-        "diff": {
-          "version": "3.3.1",
-          "resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
-          "integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww=="
-        },
-        "growl": {
-          "version": "1.10.3",
-          "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
-          "integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q=="
-        },
-        "has-flag": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
-        },
-        "mocha": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/mocha/-/mocha-4.1.0.tgz",
-          "integrity": "sha512-0RVnjg1HJsXY2YFDoTNzcc1NKhYuXKRrBAG2gDygmJJA136Cs2QlRliZG1mA0ap7cuaT30mw16luAeln+4RiNA==",
+        "resolve": {
+          "version": "1.8.1",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
+          "integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
           "requires": {
-            "browser-stdout": "1.3.0",
-            "commander": "2.11.0",
-            "debug": "3.1.0",
-            "diff": "3.3.1",
-            "escape-string-regexp": "1.0.5",
-            "glob": "7.1.2",
-            "growl": "1.10.3",
-            "he": "1.1.1",
-            "mkdirp": "0.5.1",
-            "supports-color": "4.4.0"
-          },
-          "dependencies": {
-            "supports-color": {
-              "version": "4.4.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
-              "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
-              "requires": {
-                "has-flag": "^2.0.0"
-              }
-            }
+            "path-parse": "^1.0.5"
+          }
+        },
+        "through2": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+          "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+          "requires": {
+            "readable-stream": "~2.3.6",
+            "xtend": "~4.0.1"
           }
         }
       }
@@ -4176,18 +4141,11 @@
       }
     },
     "supports-color": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-      "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
       "requires": {
-        "has-flag": "^1.0.0"
-      },
-      "dependencies": {
-        "has-flag": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
-        }
+        "has-flag": "^3.0.0"
       }
     },
     "syntax-error": {

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "coverify": "^1.4.1",
     "glob": "^7.1.2",
     "min-wd": "^2.11.0",
-    "mocaccino": "^3.0.0",
+    "mocaccino": "^4.0.0",
     "mocha": "^5.2.0",
     "puppeteer": "^1.10.0",
     "resolve": "^1.5.0",


### PR DESCRIPTION
Mocaccino used to load Mocha 4 still, causing two Mocha versions to be installed.

This is going to be a patch for v6.