### PR TITLE
Serve files with content-type headers

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -3,6 +3,7 @@
 var fs = require('fs');
 var path = require('path');
 var https = require('https');
+var mime = require('mime');
 
 module.exports = function (port, callback) {
   var server = https.createServer({
@@ -20,7 +21,9 @@ module.exports = function (port, callback) {
           res.end();
           return;
         }
-        res.writeHead(200);
+        res.writeHead(200, {
+          'Content-Type': mime.getType(file)
+        });
         fs.createReadStream(file).pipe(res);
       });
     }

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "consolify": "^2.1.0",
     "coverify": "^1.4.1",
     "glob": "^7.1.2",
+    "mime": "^2.3.1",
     "min-wd": "^2.11.0",
     "mocaccino": "^4.0.0",
     "mocha": "^5.2.0",


### PR DESCRIPTION
This adds `mime` as a dependency to lookup the content-type based on the file extension. This package was chosen because it's already used by Puppeteer, hence it's not adding any weight.

Fixes the failing webworker test in https://github.com/sinonjs/sinon/pull/1950 🎉