### PR TITLE
Add note about required flags in CircleCI

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ the test framework.
 - Run tests in Headless Chrome
     - Supports watch-mode with pre-loaded Chrome page (with `--watch`)
     - Use the Chrome developer tools for debugging ([docs](#debugging))
-    - Run builds on Travis ([docs](#travis))
+    - Run builds in CI ([docs](#continuous-integration))
     - Load tests in the context of a file or URL (with `--url`)
     - Optional built-in HTTPS server (with `--https-server`)
 - Run tests in real browsers
@@ -130,10 +130,11 @@ break at the `debugger` statement.
 - `--help` or `-h` shows usage and all available options.
 - `--async-polling` disables async polling when set to false (for use in Appium).
 
-## Travis
+## Continuous Integration
 
-To run builds on Travis, you must pass `--allow-chrome-as-root`. Here is a
-minimal `.travis.yml`:
+To run builds in CI services like Travis or CircleCI, you must pass `--allow-chrome-as-root`.
+
+Here is a minimal `.travis.yml`:
 
 ```yml
 language: node_js


### PR DESCRIPTION
I found that with v6 all of my CircleCI builds using mochify would suddenly stop running and instead timeout showing:

```
(node:173) UnhandledPromiseRejectionWarning: Error: Protocol error (Page.enable): Target closed.
    at Promise (/home/circleci/repo/node_modules/puppeteer/lib/Connection.js:186:56)
    at new Promise (<anonymous>)
    at CDPSession.send (/home/circleci/repo/node_modules/puppeteer/lib/Connection.js:185:12)
    at Function.create (/home/circleci/repo/node_modules/puppeteer/lib/Page.js:44:18)
    at _pagePromise._sessionFactory.then.client (/home/circleci/repo/node_modules/puppeteer/lib/Target.js:43:32)
    at <anonymous>
    at process._tickCallback (internal/process/next_tick.js:189:7)
```

which seems to be due to no `--allow-chrome-as-root` flag being passed (which I didn't have to do in v5, but that probably happened with the Puppeteer update).

This just adds a note to the README, making the existing section not only about Travis.