### PR TITLE
Handle promise rejection when calling browser.newPage()

### DIFF
--- a/lib/chromium.js
+++ b/lib/chromium.js
@@ -87,7 +87,7 @@ module.exports = function (b, opts) {
 
       if (!input) {
         pageFinish();
-        return;
+        return null;
       }
 
       var viewport = page.viewport();
@@ -156,7 +156,7 @@ module.exports = function (b, opts) {
       // We need a "real" web page loaded from a URL, or things like
       // localStorage are disabled.
       var pageUrl = opts.url || DEFAULT_URL;
-      page.goto(pageUrl).then(function () {
+      return page.goto(pageUrl).then(function () {
         if (!input) {
           // Bundle error.
           pageFinish();
@@ -179,10 +179,10 @@ module.exports = function (b, opts) {
             pageFinish();
           }
         });
-      }).catch(function (err) {
-        b.emit('error', err);
-        finish();
       });
+    }).catch(function (err) {
+      b.emit('error', err);
+      finish();
     });
   };
 


### PR DESCRIPTION
When looking at the issue from #189 I noticed that errors when calling browser.newPage() will never be handled (thus causing timeouts). This is the full stack trace for the `UnhandledPromiseRejectionWarning`:

```
(node:173) UnhandledPromiseRejectionWarning: Error: Protocol error (Page.enable): Target closed.
    at Promise (/home/circleci/repo/node_modules/puppeteer/lib/Connection.js:186:56)
    at new Promise (<anonymous>)
    at CDPSession.send (/home/circleci/repo/node_modules/puppeteer/lib/Connection.js:185:12)
    at Function.create (/home/circleci/repo/node_modules/puppeteer/lib/Page.js:44:18)
    at _pagePromise._sessionFactory.then.client (/home/circleci/repo/node_modules/puppeteer/lib/Target.js:43:32)
    at <anonymous>
    at process._tickCallback (internal/process/next_tick.js:189:7)
  -- ASYNC --
    at Target.<anonymous> (/home/circleci/repo/node_modules/puppeteer/lib/helper.js:144:27)
    at Browser._createPageInContext (/home/circleci/repo/node_modules/puppeteer/lib/Browser.js:177:31)
    at <anonymous>
    at process._tickCallback (internal/process/next_tick.js:189:7)
  -- ASYNC --
    at Browser.<anonymous> (/home/circleci/repo/node_modules/puppeteer/lib/helper.js:144:27)
    at load (/home/circleci/repo/node_modules/mochify/lib/chromium.js:77:13)
    at /home/circleci/repo/node_modules/mochify/lib/chromium.js:196:5
    at <anonymous>
    at process._tickCallback (internal/process/next_tick.js:189:7)
```