### PR TITLE
Enable support for passing --dumpio to Puppeteer

### DIFF
--- a/lib/args.js
+++ b/lib/args.js
@@ -15,6 +15,7 @@ var defaults = {
   cover: false,
   node: false,
   debug: false,
+  dumpio: false,
   wd: false,
   recursive: false,
   'ignore-ssl-errors': false,
@@ -36,7 +37,7 @@ function args(argv) {
       'mocha-path'],
     boolean: ['help', 'version', 'watch', 'cover', 'node', 'wd', 'debug',
       'invert', 'recursive', 'colors', 'ignore-ssl-errors', 'browser-field',
-      'commondir', 'allow-chrome-as-root', 'async-polling'],
+      'commondir', 'allow-chrome-as-root', 'async-polling', 'dumpio'],
     alias: {
       help: 'h',
       version: 'v',

--- a/lib/chromium.js
+++ b/lib/chromium.js
@@ -41,6 +41,7 @@ module.exports = function (b, opts) {
 
   var options = {
     devtools: !!opts.debug,
+    dumpio: !!opts.dumpio,
     ignoreHTTPSErrors: opts['ignore-ssl-errors'],
     args: ['--allow-insecure-localhost']
   };
@@ -52,6 +53,7 @@ module.exports = function (b, opts) {
   if (opts.chrome) {
     options.executablePath = opts.chrome;
   }
+
 
   function finish() {
     if (output) {

--- a/test/args-test.js
+++ b/test/args-test.js
@@ -135,6 +135,12 @@ describe('args', function () {
     assert.equal(opts.chrome, '/foo/bar');
   });
 
+  it('parses --dumpio', function () {
+    var opts = args(['--dumpio']);
+
+    assert(opts.dumpio);
+  });
+
   it('parses --ignore-ssl-errors', function () {
     var opts = args(['--ignore-ssl-errors']);
     assert(opts['ignore-ssl-errors']);

--- a/test/chromium-test.js
+++ b/test/chromium-test.js
@@ -121,6 +121,62 @@ describe('chromium', function () {
     });
   });
 
+  it('outputs a minimal error message to stderr when --dumpio is not specified',
+    function (done) {
+      run('fails', ['-R', 'dot', '--no-colors'],
+        function (code, stdout, stderr) {
+          assert.equal(stderr, 'Error: Exit 1\n\n');
+          assert.equal(code, 1);
+          done();
+        });
+    }
+  );
+
+  it('receives all console errors on stderr when --dumpio is given',
+    function (done) {
+      run('fails', ['-R', 'dot', '--no-colors', '--dumpio'],
+        function (code, stdout, stderr) {
+
+          var stdoutLines = stdout.split('\n').slice(1); // skip 'chromium:'
+
+          /* eslint-disable max-len */
+          // The sub-set lines actually relating to the console output.
+          // Other lines may relate to internal Chrome errors, such as
+          // '[0322/162300.874805:ERROR:command_buffer_proxy_impl.cc(125)] ContextResult::kTransientFailure: Failed to send GpuChannelMsg_CreateCommandBuffer.'
+          var stderrLines = stderr
+            .split('\n')
+            .filter(function (l) { return l.indexOf('INFO:CONSOLE') >= 0; });
+
+          // What actually ends up on the output is quite unstable:
+          // Ref https://gist.github.com/fatso83/2bb8c4ff82fa66f66db5030b0af06d66
+          // Sometimes you get a stack dump, sometimes not.
+          // We just check the portion that actually seems to always be present
+          /* eslint-enable */
+          var numberOfLinesToCheck = 3;
+
+          for (var index = 0; index < numberOfLinesToCheck; index++) {
+            var stdoutLine = stdoutLines[index];
+            var stderrLine = stderrLines[index];
+            var assertionError = 'Should have matched: \''
+              + stdoutLine
+              + '\' with \''
+              + stderrLine
+              + '\'';
+
+            assert(stderrLine.match(stdoutLine), assertionError);
+            assert(
+              stderrLine.match(/^\[.*:INFO:CONSOLE\(\d+\)\] "/),
+              assertionError);
+            assert(
+              stderrLine.match(/source: __puppeteer_evaluation_script__/),
+              assertionError);
+          }
+
+          assert.equal(code, 1);
+          done();
+        });
+    });
+
   it('uses custom chrome', function (done) {
     run('passes', ['--chrome', 'some/path'], function (code, stdout, stderr) {
       assert.equal(stdout, '');


### PR DESCRIPTION
To make debugging easier, support passing this option on to puppeteer.

With regards to the test, I am not at all sure it's what you want. I just wasn't able to figure out how to do a regex match that would produce meaningful assertion errors using the standard `assert` module, so I decided just to test on a subset of the string.

closes #199 

Background: sinonjs/sinon#1999