### PR TITLE
[feat] Bring back --web-security flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ break at the `debugger` statement.
 - `--help` or `-h` shows usage and all available options.
 - `--async-polling` disables async polling when set to false (for use in Appium).
 - `--mocha-path` specifies path to a custom Mocha module
+- `--web-security` allows disabling same-origin policy (when set to `false`, passes down `--disable-web-security` to Chromium)
 
 ## Continuous Integration
 

--- a/lib/args.js
+++ b/lib/args.js
@@ -34,7 +34,7 @@ function args(argv) {
       'yields', 'transform', 'global-transform', 'plugin', 'grep', 'url',
       'require', 'extension', 'bundle', 'wd-file', 'path', 'external',
       'viewport-width', 'viewport-height', 'outfile', 'https-server',
-      'mocha-path'],
+      'mocha-path', 'web-security'],
     boolean: ['help', 'version', 'watch', 'cover', 'node', 'wd', 'debug',
       'invert', 'recursive', 'colors', 'ignore-ssl-errors', 'browser-field',
       'commondir', 'allow-chrome-as-root', 'async-polling', 'dumpio'],

--- a/lib/chromium.js
+++ b/lib/chromium.js
@@ -50,6 +50,10 @@ module.exports = function (b, opts) {
     options.args.push('--no-sandbox', '--disable-setuid-sandbox');
   }
 
+  if (opts['web-security'] === false) {
+    options.args.push('--disable-web-security');
+  }
+
   if (opts.chrome) {
     options.executablePath = opts.chrome;
   }

--- a/test/args-test.js
+++ b/test/args-test.js
@@ -309,6 +309,20 @@ describe('args', function () {
     assert.equal(opts['async-polling'], false);
   });
 
+  it('parses --web-security', function () {
+    var opts = args(['--web-security', 'true']);
+
+    assert.equal(opts['web-security'], true);
+
+    opts = args(['--web-security', 'false']);
+
+    assert.equal(opts['web-security'], false);
+
+    opts = args(['--web-security', 'blah']);
+
+    assert.equal(opts['web-security'], false);
+  });
+
   it('fails with invert but no grep option', function (done) {
     run('passes', ['--invert'], function (code, stdout) {
       assert.equal(code, 1);

--- a/test/chromium-test.js
+++ b/test/chromium-test.js
@@ -174,6 +174,25 @@ describe('chromium', function () {
     });
   });
 
+  it('passes through web-security flag', function (done) {
+    run('web-security', ['--web-security', 'false'],
+      function (code, stdout, stderr) {
+        assert.equal(stderr, '');
+        assert.equal(code, 0);
+        done();
+      });
+  });
+
+  it('fails a cross-site XHR when web-security is not disabled',
+    function (done) {
+      run('web-security', ['--web-security', 'true'],
+        function (code, stdout, stderr) {
+          assert.ok(stderr.indexOf('CORS') > -1);
+          assert.notEqual(code, 0);
+          done();
+        });
+    });
+
   it('requires file', function (done) {
     run('require', ['-R', 'tap', '-r', '../required'], function (code, stdout) {
       assert.equal(stdout.split('\n')[2], 'required');

--- a/test/chromium-test.js
+++ b/test/chromium-test.js
@@ -11,6 +11,7 @@
 var assert = require('assert');
 var fs = require('fs');
 var net = require('net');
+var http = require('http');
 var run = require('./fixture/run');
 var sandbox = require('./fixture/sandbox');
 
@@ -173,25 +174,6 @@ describe('chromium', function () {
       done();
     });
   });
-
-  it('passes through web-security flag', function (done) {
-    run('web-security', ['--web-security', 'false'],
-      function (code, stdout, stderr) {
-        assert.equal(stderr, '');
-        assert.equal(code, 0);
-        done();
-      });
-  });
-
-  it('fails a cross-site XHR when web-security is not disabled',
-    function (done) {
-      run('web-security', ['--web-security', 'true'],
-        function (code, stdout, stderr) {
-          assert.ok(stderr.indexOf('CORS') > -1);
-          assert.notEqual(code, 0);
-          done();
-        });
-    });
 
   it('requires file', function (done) {
     run('require', ['-R', 'tap', '-r', '../required'], function (code, stdout) {
@@ -488,6 +470,42 @@ describe('chromium', function () {
               'Error message did not contain port value'
             );
             assert.equal(code, 1);
+            done();
+          });
+      });
+  });
+
+  context('--web-security flag', function () {
+    /** @type {http.Server} */
+    var server;
+
+    before(function (done) {
+      server = http.createServer(function (req, res) {
+        res.statusCode = 200;
+        res.end();
+      });
+      server.listen(3001, 'localhost', done);
+    });
+
+    after(function () {
+      server.close();
+    });
+
+    it('can be disabled', function (done) {
+      run('web-security', ['--web-security', 'false'],
+        function (code, stdout, stderr) {
+          assert.equal(stderr, '');
+          assert.equal(code, 0);
+          done();
+        });
+    });
+
+    it('defaults to enabled',
+      function (done) {
+        run('web-security', [],
+          function (code, stdout, stderr) {
+            assert.ok(stderr.indexOf('CORS') > -1);
+            assert.notEqual(code, 0);
             done();
           });
       });

--- a/test/fixture/web-security/test.html
+++ b/test/fixture/web-security/test.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<html><body><h1>Oh, hi!</h1></body></html>

--- a/test/fixture/web-security/test.html
+++ b/test/fixture/web-security/test.html
@@ -1,2 +1,0 @@
-<!DOCTYPE html>
-<html><body><h1>Oh, hi!</h1></body></html>

--- a/test/fixture/web-security/test/web-security.js
+++ b/test/fixture/web-security/test/web-security.js
@@ -1,0 +1,18 @@
+/*global describe, it, XMLHttpRequest*/
+'use strict';
+
+describe('test', function () {
+
+  it('makes an ajax call to another domain', function (done) {
+    var xhr = new XMLHttpRequest();
+    xhr.addEventListener('load', function () {
+      done();
+    });
+    xhr.addEventListener('error', function () {
+      done(new Error('XHR error'));
+    });
+    xhr.open('GET', 'https://www.github.com/mantoni/mochify.js');
+    xhr.send();
+  });
+
+});

--- a/test/fixture/web-security/test/web-security.js
+++ b/test/fixture/web-security/test/web-security.js
@@ -11,7 +11,7 @@ describe('test', function () {
     xhr.addEventListener('error', function () {
       done(new Error('XHR error'));
     });
-    xhr.open('GET', 'https://www.github.com/mantoni/mochify.js');
+    xhr.open('GET', 'http://localhost:3001');
     xhr.send();
   });
 


### PR DESCRIPTION
There used to be a flag in old versions called `--web-security` (added in #71) which allowed disabling the same-origin policy in Phantom. Now that we use Puppeteer/Chromium, that flag was removed. This PR adds it back in with the exact same semantics it used to have, but it now passes through to Chromium.

Happy to adjust as needed. Thanks!