### PR TITLE
Introduce `--no-request-interception`

### DIFF
--- a/lib/args.js
+++ b/lib/args.js
@@ -25,7 +25,8 @@ var defaults = {
   timeout: '2000',
   yields: '0',
   colors: null,
-  'async-polling': true
+  'async-polling': true,
+  'request-interception': true
 };
 
 function args(argv) {
@@ -37,7 +38,8 @@ function args(argv) {
       'mocha-path', 'web-security'],
     boolean: ['help', 'version', 'watch', 'cover', 'node', 'wd', 'debug',
       'invert', 'recursive', 'colors', 'ignore-ssl-errors', 'browser-field',
-      'commondir', 'allow-chrome-as-root', 'async-polling', 'dumpio'],
+      'commondir', 'allow-chrome-as-root', 'async-polling', 'dumpio',
+      'request-interception'],
     alias: {
       help: 'h',
       version: 'v',

--- a/lib/chromium.js
+++ b/lib/chromium.js
@@ -175,16 +175,21 @@ module.exports = function (b, opts) {
         output.write('\n');
       });
 
-      // Prevent image and font requests from causing error messages:
-      page.setRequestInterception(true);
-      page.on('request', function (request) {
-        if (IGNORE_RESOURCE_TYPES[request.resourceType()]) {
-          // Respond with 200 ok or a warning is logged:
-          request.respond({ status: 200 });
-        } else {
-          request.continue();
-        }
-      });
+      // This switch can be used to work around an issue in puppeteer when
+      // running scripts within a web worker. See
+      // https://github.com/GoogleChrome/puppeteer/issues/4208
+      if (opts['request-interception']) {
+        // Prevent image and font requests from causing error messages:
+        page.setRequestInterception(true);
+        page.on('request', function (request) {
+          if (IGNORE_RESOURCE_TYPES[request.resourceType()]) {
+            // Respond with 200 ok or a warning is logged:
+            request.respond({ status: 200 });
+          } else {
+            request.continue();
+          }
+        });
+      }
 
       // We need a "real" web page loaded from a URL, or things like
       // localStorage are disabled.

--- a/test/args-test.js
+++ b/test/args-test.js
@@ -30,6 +30,7 @@ describe('args', function () {
     assert.equal(opts['ignore-ssl-errors'], false);
     assert.equal(opts['browser-field'], true);
     assert.equal(opts.commondir, true);
+    assert.equal(opts['request-interception'], true);
   });
 
   it('parses --reporter', function () {
@@ -321,6 +322,12 @@ describe('args', function () {
     opts = args(['--web-security', 'blah']);
 
     assert.equal(opts['web-security'], false);
+  });
+
+  it('parses --no-request-interception', function () {
+    var opts = args(['--no-request-interception']);
+
+    assert.equal(opts['request-interception'], false);
   });
 
   it('fails with invert but no grep option', function (done) {

--- a/test/chromium-test.js
+++ b/test/chromium-test.js
@@ -453,6 +453,16 @@ describe('chromium', function () {
     });
   });
 
+  it('allows to turn off request interception', function (done) {
+    run('requests', ['-R', 'tap', '--no-request-interception'],
+      function (code, stdout, stderr) {
+        assert.equal(stderr,
+          'Failed to load resource: net::ERR_FILE_NOT_FOUND\n');
+        assert.equal(code, 0);
+        done();
+      });
+  });
+
   context('https-server with a port value given', function () {
     var server;
     var port;


### PR DESCRIPTION
This works around a puppeteer issue when running scripts within a web worker. See https://github.com/GoogleChrome/puppeteer/issues/4208 for details.