### PR TITLE
Add support for the browserify `--no-detect-globals` option

### DIFF
--- a/lib/args.js
+++ b/lib/args.js
@@ -26,7 +26,8 @@ var defaults = {
   yields: '0',
   colors: null,
   'async-polling': true,
-  'request-interception': true
+  'request-interception': true,
+  'detect-globals': true
 };
 
 function args(argv) {
@@ -39,7 +40,7 @@ function args(argv) {
     boolean: ['help', 'version', 'watch', 'cover', 'node', 'wd', 'debug',
       'invert', 'recursive', 'colors', 'ignore-ssl-errors', 'browser-field',
       'commondir', 'allow-chrome-as-root', 'async-polling', 'dumpio',
-      'request-interception'],
+      'request-interception', 'detect-globals'],
     alias: {
       help: 'h',
       version: 'v',

--- a/lib/mochify.js
+++ b/lib/mochify.js
@@ -128,6 +128,8 @@ module.exports = function (_, opts) {
     brOpts.commondir = false;
     brOpts.detectGlobals = false;
     brOpts.insertGlobalVars = ['__dirname', '__filename'];
+  } else {
+    brOpts.detectGlobals = opts['detect-globals'];
   }
   brOpts.extensions = opts.extension;
   brOpts.browserField = opts['browser-field'];

--- a/package-lock.json
+++ b/package-lock.json
@@ -382,9 +382,9 @@
       "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
     },
     "brout": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/brout/-/brout-1.2.0.tgz",
-      "integrity": "sha1-B3Hav3ltMS8KfB8SgeAPdmDPcC8=",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/brout/-/brout-1.3.0.tgz",
+      "integrity": "sha512-wCMjZMH6sCUytoS/aqJBajJREN2wS1GnsNyBqB/Ss1hrcCh0no+Zgk+ebFp9s2yh5lxGfXBRXwNH2N3Ma2RFdQ==",
       "requires": {
         "through2": "^2.0.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2707,11 +2707,11 @@
       }
     },
     "mocaccino": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/mocaccino/-/mocaccino-4.1.0.tgz",
-      "integrity": "sha512-loaQBMkb3JgODJJHdaA8/pA//EiTJo5+L8MVQVSXpHdMWvZ8tjUA6OaAmKD8qEuTBNIOv0xqH+eXlWP50dcp5Q==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/mocaccino/-/mocaccino-4.1.2.tgz",
+      "integrity": "sha512-lTlZ47MiMVco1gQhYGh75/U6t6cMNxLVhQTLNsJWPZlWY9dlF+SS9vKrnjaNpRzYThh8yVJpI8+hpChyUj+Qzg==",
       "requires": {
-        "brout": "^1.1.0",
+        "brout": "^1.3.0",
         "listen": "^1.0.0",
         "mocha": "^5.2.0",
         "resolve": "^1.8.1",
@@ -2725,9 +2725,9 @@
           "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
         },
         "resolve": {
-          "version": "1.10.0",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.0.tgz",
-          "integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
+          "version": "1.12.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.12.0.tgz",
+          "integrity": "sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==",
           "requires": {
             "path-parse": "^1.0.6"
           }

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "glob": "^7.1.2",
     "mime": "^2.3.1",
     "min-wd": "^2.11.0",
-    "mocaccino": "^4.1.0",
+    "mocaccino": "^4.1.2",
     "mocha": "^5.2.0",
     "puppeteer": "^1.19.0",
     "resolve": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "url": "https://github.com/mantoni/mochify.js.git"
   },
   "dependencies": {
-    "brout": "^1.1.0",
+    "brout": "^1.3.0",
     "browserify": "^16.2.3",
     "consolify": "^2.1.0",
     "coverify": "^1.4.1",

--- a/test/args-test.js
+++ b/test/args-test.js
@@ -31,6 +31,7 @@ describe('args', function () {
     assert.equal(opts['browser-field'], true);
     assert.equal(opts.commondir, true);
     assert.equal(opts['request-interception'], true);
+    assert.equal(opts['detect-globals'], true);
   });
 
   it('parses --reporter', function () {
@@ -328,6 +329,18 @@ describe('args', function () {
     var opts = args(['--no-request-interception']);
 
     assert.equal(opts['request-interception'], false);
+  });
+
+  it('parses --detect-globals', function () {
+    var opts = args(['--detect-globals']);
+
+    assert(opts['detect-globals']);
+  });
+
+  it('parses --no-detect-globals', function () {
+    var opts = args(['--no-detect-globals']);
+
+    assert.equal(opts['detect-globals'], false);
   });
 
   it('fails with invert but no grep option', function (done) {

--- a/test/chromium-test.js
+++ b/test/chromium-test.js
@@ -463,6 +463,24 @@ describe('chromium', function () {
       });
   });
 
+  it('detects globals by default', function (done) {
+    run('detect-globals', ['-R', 'tap'],
+      function (code, stdout, stderr) {
+        assert.equal(stderr, 'object\n');
+        assert.equal(code, 0);
+        done();
+      });
+  });
+
+  it('allows to turn off global detection', function (done) {
+    run('detect-globals', ['--no-detect-globals'],
+      function (code, stdout, stderr) {
+        assert.equal(stderr, 'undefined\n');
+        assert.equal(code, 0);
+        done();
+      });
+  });
+
   context('https-server with a port value given', function () {
     var server;
     var port;

--- a/test/chromium-test.js
+++ b/test/chromium-test.js
@@ -481,6 +481,16 @@ describe('chromium', function () {
       });
   });
 
+  // Verify that the `--yields` option does not assume `process.nextTick`.
+  it('works with async tests and yields', function (done) {
+    run('async', ['--no-detect-globals', '--yields', '1'],
+      function (code, stdout, stderr) {
+        assert.equal(stderr, '');
+        assert.equal(code, 0);
+        done();
+      });
+  });
+
   context('https-server with a port value given', function () {
     var server;
     var port;

--- a/test/fixture/async/test/async.js
+++ b/test/fixture/async/test/async.js
@@ -1,0 +1,10 @@
+/*global describe, it*/
+'use strict';
+
+describe('async', function () {
+
+  it('works', function (done) {
+    setTimeout(done, 1);
+  });
+
+});

--- a/test/fixture/detect-globals/test/global.js
+++ b/test/fixture/detect-globals/test/global.js
@@ -1,0 +1,10 @@
+/*global describe, it*/
+'use strict';
+
+describe('global', function () {
+
+  it('prints typeof global', function () {
+    console.error(typeof global);
+  });
+
+});


### PR DESCRIPTION
By default, browserify detects the use of global like `process` and `global`. This is sometimes undesireable and recently caused issues with upgrading browserify in the Sinon projects (see https://github.com/sinonjs/commons/pull/37, https://github.com/sinonjs/sinon/pull/2119 and most importantly the analysis from @fatso83 in https://github.com/sinonjs/sinon/issues/2085).

Allowing to turn off this browserify behavior brought a chain of other issues to the light:

- The `brout` project (used internally) assumed that `process` is shimed. This has been addressed in `v1.3.0` (see https://github.com/mantoni/brout.js/commit/9fc88568629256cf47f03e8744124f50e4651a64).
- The `mocaccino` project (also used internally) assumed that `process.nextTick` is shimed. This has been addressed in `v4.1.2` (see https://github.com/mantoni/mocaccino.js/commit/f46487a16d1da04bcad60d111ea98b900e2b62e4).

Unfortunately, the `process` object _must_ be installed by `brout`, or most Mocha reporters would stop working. However, it's a good improvement to not have `global` and things like `process.nextTick` shimed by browserify in our test runs.

I have tested these changes with the Sinon project by adding the switch. This highlights several issues with feature detections, mostly in the test cases, but also in `lolex`. Once this change has been released, I'll send PRs with fixes for those projects.