### PR TITLE
Improve docs for nyc coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,8 +330,8 @@ The `mochify` function returns a Browserify instance. Please refer to the
 
 ## Code coverage with NYC
 
-Install `nyc`, the `babelify` transform, `@babel/core` and
-`babel-plugin-istanbul`:
+Install `nyc@14` (v15 is not yet supported!), the `babelify` transform,
+`@babel/core` and `babel-plugin-istanbul`:
 
 ```bash
 $ npm install nyc babelify @babel/core babel-plugin-istanbul --save-dev


### PR DESCRIPTION
- v15 is not yet supported (see https://github.com/istanbuljs/nyc/commit/cfd3da05156b98952f03f7be2dd3d23ba328073f)
- The babel plugin should run globally for some special cases to work