### PR TITLE
Support nyc v15

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,7 +330,7 @@ The `mochify` function returns a Browserify instance. Please refer to the
 
 ## Code coverage with NYC
 
-Install `nyc@14` (v15 is not yet supported!), the `babelify` transform,
+Install `nyc`, the `babelify` transform,
 `@babel/core` and `babel-plugin-istanbul`:
 
 ```bash

--- a/lib/chromium.js
+++ b/lib/chromium.js
@@ -128,7 +128,7 @@ module.exports = function (b, opts) {
         if (text.indexOf('[COVERAGE ') === 0) {
           var nycRootID = process.env.NYC_ROOT_ID;
           if (!nycRootID) {
-            // NYC >v15 does not export a NYC_ROOT_ID so use a "random" uuid instead
+            // NYC >v15 does not export a NYC_ROOT_ID so use a "random" uuid
             nycRootID = '4638ceac-c8d9-411d-9e1f-72755846a221';
           }
           var nycConfig = JSON.parse(process.env.NYC_CONFIG);

--- a/lib/chromium.js
+++ b/lib/chromium.js
@@ -126,19 +126,19 @@ module.exports = function (b, opts) {
           return;
         }
         if (text.indexOf('[COVERAGE ') === 0) {
-          if (process.env.NYC_ROOT_ID) {
-            var nycConfig = JSON.parse(process.env.NYC_CONFIG);
-            var json = text.substring(10, text.length - 1);
-            var file = path.join(nycConfig.tempDir,
-              process.env.NYC_ROOT_ID + '.json');
-            fs.writeFile(file, json, 'utf8', function (err) {
-              if (err) {
-                b.emit('error', err);
-              }
-            });
-            return;
+          var nycRootID = process.env.NYC_ROOT_ID;
+          if (!nycRootID) {
+            // NYC >v15 does not export a NYC_ROOT_ID so use a "random" uuid instead
+            nycRootID = '4638ceac-c8d9-411d-9e1f-72755846a221';
           }
-          output.write('Coverage information received, but no nyc\n');
+          var nycConfig = JSON.parse(process.env.NYC_CONFIG);
+          var json = text.substring(10, text.length - 1);
+          var file = path.join(nycConfig.tempDir, nycRootID + '.json');
+          fs.writeFile(file, json, 'utf8', function (err) {
+            if (err) {
+              b.emit('error', err);
+            }
+          });
           return;
         }
         if (text.indexOf('[EXIT ') === 0) {


### PR DESCRIPTION
From what I can tell, the only thing that breaks with nyc v15 is that it removes `NYC_ROOT_ID` (https://github.com/istanbuljs/nyc/blob/master/CHANGELOG.md#-breaking-changes) which is depended on by mochify.  I'm not sure how the ID is used, but it seems like any ID will work.  Therefore, for nyc>=15, I'm generating a random `NYC_ROOT_ID`.  