### PR TITLE
Migrate CI to GitHub actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,28 @@
+name: Build
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version:
+          - '12'
+          - '14'
+          - '16'
+    steps:
+     - uses: actions/checkout@v2
+     - uses: actions/setup-node@v2
+       with:
+         node-version: ${{ matrix.node-version }}
+     - name: Install dependencies
+       run: npm ci
+     - name: Run tests
+       run: npm t

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,0 @@
-language: node_js
-node_js:
-  - "12"
-  - "14"
-  - "16"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > TDD with Browserify, Mocha, Headless Chrome and WebDriver
 
-[![Build Status](https://travis-ci.org/mantoni/mochify.js.svg?branch=master)](https://travis-ci.org/mantoni/mochify.js)
+[![Build](https://github.com/mantoni/mochify.js/actions/workflows/test.yml/badge.svg)](https://github.com/mantoni/mochify.js/actions/workflows/test.yml)
 [![SemVer]](http://semver.org)
 [![License]](https://github.com/mantoni/mochify.js/blob/master/LICENSE)
 


### PR DESCRIPTION
The __org__ version of Travis seems to be shutting down on the 15th of June which isn't that far into the future anymore.

It would be possible to migrate the setup to the __com__ version (https://docs.travis-ci.com/user/migrate/open-source-repository-migration), but tbh that feels like a dead end. Instead, Mochify can use GitHub actions I guess.