### PR TITLE
Clean up package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5450,7 +5450,8 @@
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.1.tgz",
       "integrity": "sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "acorn-node": {
       "version": "1.8.2",
@@ -9371,7 +9372,8 @@
     "ws": {
       "version": "7.4.5",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.5.tgz",
-      "integrity": "sha512-xzyu3hFvomRfXKH8vOFMU3OguG6oOvhXMo3xsGy3xWExqaM2dxBbVxuD99O7m3ZUFMvvscsZDqxfgMaRr/Nr1g=="
+      "integrity": "sha512-xzyu3hFvomRfXKH8vOFMU3OguG6oOvhXMo3xsGy3xWExqaM2dxBbVxuD99O7m3ZUFMvvscsZDqxfgMaRr/Nr1g==",
+      "requires": {}
     },
     "xtend": {
       "version": "4.0.2",


### PR DESCRIPTION
A simple `npm install` on top of the current master commit (3179da8).  I believe the changes in this PR were lost in some previous PR, perhaps because of past rebase/merge conflict resolution.