### PR TITLE
Add playwright driver

### DIFF
--- a/driver-playwright/index.html
+++ b/driver-playwright/index.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<html><meta charset="utf-8"><body></body></html>

--- a/driver-playwright/index.js
+++ b/driver-playwright/index.js
@@ -1,0 +1,67 @@
+'use strict';
+
+const driver = require('playwright');
+
+exports.mochifyDriver = mochifyDriver;
+
+async function mochifyDriver(options = {}) {
+  options = Object.assign(
+    {
+      engine: 'firefox',
+      url: `file:${__dirname}/index.html`,
+      stderr: process.stderr
+    },
+    options
+  );
+
+  const stderr = options.stderr;
+  const browser = await driver[options.engine].launch({
+    ignoreHTTPSErrors: true
+  });
+
+  const page = await browser.newPage();
+  page.on('console', (msg) => {
+    const type = msg.type();
+    const text = msg.text();
+    if (type === 'log') {
+      return;
+    }
+
+    const ignoreList = [
+      'onmozfullscreenerror',
+      'window.webkitStorageInfo',
+      'onmozfullscreenchange'
+    ];
+
+    if (type === 'warning' && ignoreList.some((t) => text.includes(t))) {
+      // Swallow deprecation warning.
+      return;
+    }
+    stderr.write(text);
+    stderr.write('\n');
+  });
+
+  page.on('error', (err) => {
+    stderr.write(err.stack || String(err));
+    stderr.write('\n');
+    process.exitCode = 1;
+    end();
+  });
+
+  async function end() {
+    await page.close();
+    await browser.close();
+  }
+
+  await page.goto(options.url);
+
+  function evaluate(script) {
+    return page.evaluate(script);
+  }
+
+  return {
+    evaluate,
+    evaluateReturn: evaluate,
+    end
+  };
+}

--- a/driver-playwright/package.json
+++ b/driver-playwright/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@mochify/driver-playwright",
+  "version": "0.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "MIT",
+  "dependencies": {
+    "playwright": "^1.12.3"
+  },
+  "peerDependencies": {
+    "@mochify/mochify": "*"
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
         "cli",
         "mochify",
         "driver-puppeteer",
-        "driver-webdriver"
+        "driver-webdriver",
+        "driver-playwright"
       ],
       "devDependencies": {
         "@studio/eslint-config": "^2.0.0",
@@ -36,6 +37,17 @@
         "@mochify/mochify": "*",
         "glob": "^7.1.7",
         "yargs": "^16.2.0"
+      }
+    },
+    "driver-playwright": {
+      "name": "@mochify/driver-playwright",
+      "version": "0.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "playwright": "^1.12.3"
+      },
+      "peerDependencies": {
+        "@mochify/mochify": "*"
       }
     },
     "driver-puppeteer": {
@@ -240,6 +252,10 @@
     },
     "node_modules/@mochify/cli": {
       "resolved": "cli",
+      "link": true
+    },
+    "node_modules/@mochify/driver-playwright": {
+      "resolved": "driver-playwright",
       "link": true
     },
     "node_modules/@mochify/driver-puppeteer": {
@@ -2418,6 +2434,11 @@
         "url": "https://github.com/sindresorhus/got?sponsor=1"
       }
     },
+    "node_modules/graceful-fs": {
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
+      "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ=="
+    },
     "node_modules/growl": {
       "version": "1.10.5",
       "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
@@ -2983,6 +3004,11 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+    },
+    "node_modules/jpeg-js": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.4.3.tgz",
+      "integrity": "sha512-ru1HWKek8octvUHFHvE5ZzQ1yAsJmIvRdGWvSoKV52XKyuyYA437QWDttXT8eZXDSbuMpHlLzPDZUPd6idIz+Q=="
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -3905,6 +3931,50 @@
         "node": ">=8"
       }
     },
+    "node_modules/playwright": {
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.12.3.tgz",
+      "integrity": "sha512-eyhHvZV7dMAUltqjQsgJ9CjZM8dznzN1+rcfCI6W6lfQ7IlPvTFGLuKOCcI4ETbjfbxqaS5FKIkb1WDDzq2Nww==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "commander": "^6.1.0",
+        "debug": "^4.1.1",
+        "extract-zip": "^2.0.1",
+        "https-proxy-agent": "^5.0.0",
+        "jpeg-js": "^0.4.2",
+        "mime": "^2.4.6",
+        "pngjs": "^5.0.0",
+        "progress": "^2.0.3",
+        "proper-lockfile": "^4.1.1",
+        "proxy-from-env": "^1.1.0",
+        "rimraf": "^3.0.2",
+        "stack-utils": "^2.0.3",
+        "ws": "^7.4.6",
+        "yazl": "^2.5.1"
+      },
+      "bin": {
+        "playwright": "lib/cli/cli.js"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/playwright/node_modules/commander": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+      "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/playwright/node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/please-upgrade-node": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/please-upgrade-node/-/please-upgrade-node-3.2.0.tgz",
@@ -3912,6 +3982,14 @@
       "dev": true,
       "dependencies": {
         "semver-compare": "^1.0.0"
+      }
+    },
+    "node_modules/pngjs": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
+      "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/prelude-ls": {
@@ -3956,6 +4034,16 @@
       "integrity": "sha512-OE+a6vzqazc+K6LxJrX5UPyKFvGnL5CYmq2jFGNIBWHpc4QyE49/YOumcrpQFJpfejmvRtbJzgO1zPmMCqlbBg==",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/proper-lockfile": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
+      "integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "retry": "^0.12.0",
+        "signal-exit": "^3.0.2"
       }
     },
     "node_modules/proxy-from-env": {
@@ -4202,6 +4290,14 @@
         "node": ">=8"
       }
     },
+    "node_modules/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/rimraf": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -4403,6 +4499,25 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
+    },
+    "node_modules/stack-utils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.3.tgz",
+      "integrity": "sha512-gL//fkxfWUsIlFL2Tl42Cl6+HFALEaB1FU76I/Fy+oZjRreP7OPMXFlGbxM7NQsI0ZpUfw76sHnv0WNYuTb7Iw==",
+      "dependencies": {
+        "escape-string-regexp": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/stack-utils/node_modules/escape-string-regexp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+      "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/stream-browserify": {
       "version": "3.0.0",
@@ -5223,6 +5338,14 @@
         "fd-slicer": "~1.1.0"
       }
     },
+    "node_modules/yazl": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/yazl/-/yazl-2.5.1.tgz",
+      "integrity": "sha512-phENi2PLiHnHb6QBVot+dJnaAZ0xosj7p3fWl+znIjBDlnMI2PsZCJZ306BPTFOaHf5qdDEI8x5qFrSOBN5vrw==",
+      "dependencies": {
+        "buffer-crc32": "~0.2.3"
+      }
+    },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
@@ -5383,6 +5506,12 @@
         "yargs": "^16.2.0"
       }
     },
+    "@mochify/driver-playwright": {
+      "version": "file:driver-playwright",
+      "requires": {
+        "playwright": "^1.12.3"
+      }
+    },
     "@mochify/driver-puppeteer": {
       "version": "file:driver-puppeteer",
       "requires": {
@@ -5392,7 +5521,7 @@
     "@mochify/driver-webdriver": {
       "version": "file:driver-webdriver",
       "requires": {
-        "webdriver": "*"
+        "webdriver": "^7.7.4"
       }
     },
     "@mochify/mochify": {
@@ -5415,8 +5544,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@studio/eslint-config/-/eslint-config-2.0.0.tgz",
       "integrity": "sha512-NSMbrOCArn22N7CW3TdZTvYVbbTvPfZEBhHP7sa0cPUFJxzt+onJvckS01HkNF5QRy54TzcCZnhwzcgc5jKIRA==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@szmarczak/http-timer": {
       "version": "4.0.5",
@@ -5560,8 +5688,7 @@
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.1.tgz",
       "integrity": "sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "acorn-node": {
       "version": "1.8.2",
@@ -7128,6 +7255,11 @@
         "responselike": "^2.0.0"
       }
     },
+    "graceful-fs": {
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
+      "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ=="
+    },
     "growl": {
       "version": "1.10.5",
       "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
@@ -7510,6 +7642,11 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+    },
+    "jpeg-js": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.4.3.tgz",
+      "integrity": "sha512-ru1HWKek8octvUHFHvE5ZzQ1yAsJmIvRdGWvSoKV52XKyuyYA437QWDttXT8eZXDSbuMpHlLzPDZUPd6idIz+Q=="
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -8204,6 +8341,39 @@
         }
       }
     },
+    "playwright": {
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.12.3.tgz",
+      "integrity": "sha512-eyhHvZV7dMAUltqjQsgJ9CjZM8dznzN1+rcfCI6W6lfQ7IlPvTFGLuKOCcI4ETbjfbxqaS5FKIkb1WDDzq2Nww==",
+      "requires": {
+        "commander": "^6.1.0",
+        "debug": "^4.1.1",
+        "extract-zip": "^2.0.1",
+        "https-proxy-agent": "^5.0.0",
+        "jpeg-js": "^0.4.2",
+        "mime": "^2.4.6",
+        "pngjs": "^5.0.0",
+        "progress": "^2.0.3",
+        "proper-lockfile": "^4.1.1",
+        "proxy-from-env": "^1.1.0",
+        "rimraf": "^3.0.2",
+        "stack-utils": "^2.0.3",
+        "ws": "^7.4.6",
+        "yazl": "^2.5.1"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "6.2.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+          "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA=="
+        },
+        "progress": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+          "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA=="
+        }
+      }
+    },
     "please-upgrade-node": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/please-upgrade-node/-/please-upgrade-node-3.2.0.tgz",
@@ -8212,6 +8382,11 @@
       "requires": {
         "semver-compare": "^1.0.0"
       }
+    },
+    "pngjs": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
+      "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw=="
     },
     "prelude-ls": {
       "version": "1.2.1",
@@ -8241,6 +8416,16 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.1.tgz",
       "integrity": "sha512-OE+a6vzqazc+K6LxJrX5UPyKFvGnL5CYmq2jFGNIBWHpc4QyE49/YOumcrpQFJpfejmvRtbJzgO1zPmMCqlbBg=="
+    },
+    "proper-lockfile": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
+      "integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
+      "requires": {
+        "graceful-fs": "^4.2.4",
+        "retry": "^0.12.0",
+        "signal-exit": "^3.0.2"
+      }
     },
     "proxy-from-env": {
       "version": "1.1.0",
@@ -8449,6 +8634,11 @@
         "signal-exit": "^3.0.2"
       }
     },
+    "retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs="
+    },
     "rimraf": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -8588,6 +8778,21 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
+    },
+    "stack-utils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.3.tgz",
+      "integrity": "sha512-gL//fkxfWUsIlFL2Tl42Cl6+HFALEaB1FU76I/Fy+oZjRreP7OPMXFlGbxM7NQsI0ZpUfw76sHnv0WNYuTb7Iw==",
+      "requires": {
+        "escape-string-regexp": "^2.0.0"
+      },
+      "dependencies": {
+        "escape-string-regexp": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+          "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="
+        }
+      }
     },
     "stream-browserify": {
       "version": "3.0.0",
@@ -9157,8 +9362,7 @@
     "ws": {
       "version": "7.4.6",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
-      "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
-      "requires": {}
+      "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A=="
     },
     "xtend": {
       "version": "4.0.2",
@@ -9250,6 +9454,14 @@
       "requires": {
         "buffer-crc32": "~0.2.3",
         "fd-slicer": "~1.1.0"
+      }
+    },
+    "yazl": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/yazl/-/yazl-2.5.1.tgz",
+      "integrity": "sha512-phENi2PLiHnHb6QBVot+dJnaAZ0xosj7p3fWl+znIjBDlnMI2PsZCJZ306BPTFOaHf5qdDEI8x5qFrSOBN5vrw==",
+      "requires": {
+        "buffer-crc32": "~0.2.3"
       }
     },
     "yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -67,7 +67,8 @@
     "cli",
     "mochify",
     "driver-puppeteer",
-    "driver-webdriver"
+    "driver-webdriver",
+    "driver-playwright"
   ],
   "devDependencies": {
     "@studio/eslint-config": "^2.0.0",


### PR DESCRIPTION
This is so eerily similar to `puppeteer` as of now, I wonder if it should share some code or if we're ok with the duplication.

Dunno about your plans, but having seen how easy this is, I would assume it makes more sense to wait with merging this while you still figure out the API and things like the testing story.

This currently works fine (running very basic stuff) with all 3 engines.