### PR TITLE
Handle uncaught exceptions in puppeteer driver

### DIFF
--- a/driver-puppeteer/index.js
+++ b/driver-puppeteer/index.js
@@ -37,12 +37,14 @@ async function mochifyDriver(options = {}) {
     stderr.write('\n');
   });
 
-  page.on('error', (err) => {
+  function handlePuppeteerError(err) {
     stderr.write(err.stack || String(err));
     stderr.write('\n');
     process.exitCode = 1;
     end();
-  });
+  }
+
+  page.on('pageerror', handlePuppeteerError).on('error', handlePuppeteerError);
 
   async function end() {
     await page.close();

--- a/mochify/lib/run.js
+++ b/mochify/lib/run.js
@@ -8,7 +8,7 @@ const { mochaEventAdapter } = require('./mocha-event-adapter');
 
 exports.run = run;
 
-function run(driver, mocha_runner, script) {
+async function run(driver, mocha_runner, script) {
   let mapStack = null;
   const source_map = fromSource(script);
   if (source_map) {
@@ -16,7 +16,7 @@ function run(driver, mocha_runner, script) {
     script = removeComments(script);
   }
 
-  injectScript(driver, script);
+  await injectScript(driver, script);
 
   const emit = mochaEventAdapter(mocha_runner, mapStack);
   return pollEvents(driver, emit);


### PR DESCRIPTION
It seems that the puppeteer driver right now does not handle uncaught exceptions that occur before mocha is set up, so if your test suite is borked, this will right now result in sth like this:

```
➜  mochify.js git:(rewrite) ✗ npm t                                                                                                                                                                        
                                                                                                                                                                                                           
> mochify@8.1.0 test                                                                                                                                                                                       
> cli/index.js --bundle 'browserify --debug' ./test.js                                                                                                                                                     
                                                                                                                                                                                                                                                                                                                                                                                                  
Error: BOOOM                                                                                                                                                                                               
    at Suite.<anonymous> (<anonymous>:7:9)                                                                                                                                                                 
    at Object.create (__puppeteer_evaluation_script__:28106:20)                                                                                                                                            
    at context.describe.context.context (__puppeteer_evaluation_script__:28181:30)                                                                                                                         
    at Object.1 (<anonymous>:6:1)                                                                                                                                                                          
    at o (<anonymous>:1:265)                                                                                                                                                                               
    at r (<anonymous>:1:431)                                                                                                                                                                               
    at <anonymous>:1:460                                                                                                                                                                                   
    at Mocha.mocha.mochify_run (__puppeteer_evaluation_script__:30594:17)                                                                                                                                  
    at __puppeteer_evaluation_script__:1:7                                                                                                                                                                 
                                                                                                                                                                                                           
                                                                                                                                                                                                           
  0 passing (0ms)          
```

exiting cleanly with code 0. To catch these, the driver needs to listen to both `error` and `pageerror`.