### PR TITLE
Use non-blocking loop to poll for events

### DIFF
--- a/mochify/lib/poll-events.js
+++ b/mochify/lib/poll-events.js
@@ -3,22 +3,28 @@
 exports.pollEvents = pollEvents;
 
 async function pollEvents(driver, emit) {
-  for (;;) {
-    const events = await driver.evaluateReturn('mocha.mochify_pollEvents()');
-    if (!events) {
-      continue;
-    }
-    for (const [event, data] of events) {
-      if (event === 'mochify.callback') {
-        return data.code || 0; // stop polling
+  let interval;
+  const result = await new Promise((resolve) => {
+    interval = setInterval(async () => {
+      const events = await driver.evaluateReturn('mocha.mochify_pollEvents()');
+      if (!events) {
+        return;
       }
-      if (event === 'mochify.coverage') {
-        global.__coverage__ = data;
-      } else if (event.startsWith('console.')) {
-        console[event.substring(8)](...data);
-      } else {
-        emit(event, data);
+      for (const [event, data] of events) {
+        if (event === 'mochify.callback') {
+          resolve(data.code || 0);
+          return; // stop polling
+        }
+        if (event === 'mochify.coverage') {
+          global.__coverage__ = data;
+        } else if (event.startsWith('console.')) {
+          console[event.substring(8)](...data);
+        } else {
+          emit(event, data);
+        }
       }
-    }
-  }
+    }, 1);
+  });
+  clearInterval(interval);
+  return result;
 }


### PR DESCRIPTION
When debugging why the `jsdom` driver that I am working on was never running any tests I found out it's because of the following:

- in this setup `mochify` and `jsdom` run on the same thread
- the infinite loop that currently polls for events from the mochify reporter is blocking
- jsdom never gets around to execute any code because it's being blocked by the mentioned for loop

This is not a problem for headless browsers et al as they run on a different thread, yet I would assume allowing drivers to use the same thread as mochify can be helpful.

---

The [jsdom driver](https://github.com/mantoni/mochify.js/tree/jsdom-driver) works now including this change, but there's a lot of clean up to do still, so I thought this should go into a dedicated PR.