### PR TITLE
Add driver options

### DIFF
--- a/cli/index.js
+++ b/cli/index.js
@@ -11,6 +11,9 @@ const opts = yargs(hideBin(process.argv))
   .option('driver', {
     type: 'string'
   })
+  .option('driver-option', {
+    type: 'object'
+  })
   .option('reporter', {
     alias: 'R',
     type: 'string'
@@ -26,6 +29,7 @@ const opts = yargs(hideBin(process.argv))
 // The bundle command to run (from config):
 const config = {
   driver: opts.driver,
+  driver_options: opts['driver-option'],
   bundle: opts.bundle,
   reporter: opts.reporter,
   serve: opts.serve,

--- a/mochify/index.js
+++ b/mochify/index.js
@@ -14,7 +14,7 @@ async function mochify(config = {}) {
   const mocha_runner = createMochaRunner(config.reporter || 'spec');
   const { mochifyDriver } = resolveMochifyDriver(config.driver);
 
-  const driver_options = {};
+  const driver_options = config.driver_options || {};
   let server = null;
   if (config.serve) {
     server = await startServer({ serve: config.serve });

--- a/test.js
+++ b/test.js
@@ -1,9 +1,10 @@
 /*eslint-env mocha*/
+/*global navigator*/
 'use strict';
 
 describe('test', () => {
   it('passes', () => {
-    console.log('Oh, hi!');
+    console.log('Oh, hi!', navigator.userAgent);
   });
 
   it('skipped');


### PR DESCRIPTION
I was thinking how we could specify driver options and pass them down. In this example, I prefixed the `engine` option (used by the playwright driver) with `--driver-`.

I can think of these naming conventions:

- `--driver-${option}`
- `--${driver}-${option}`
- `--driver-${driver}-${option}`

Or we re-introduce the [subarg](https://www.npmjs.com/package/subarg) module and allow `--driver-options [ --engine webkit ]`.

What do you think?