### PR TITLE
Remove --server option in favor of --serve

### DIFF
--- a/cli/index.js
+++ b/cli/index.js
@@ -21,9 +21,6 @@ const opts = yargs(hideBin(process.argv))
   .option('serve', {
     type: 'string'
   })
-  .option('server', {
-    type: 'boolean'
-  })
   .parse();
 
 // The bundle command to run (from config):

--- a/mochify/index.js
+++ b/mochify/index.js
@@ -16,9 +16,8 @@ async function mochify(config = {}) {
 
   const driver_options = {};
   let server = null;
-  if (config.serve || config.server) {
-    const server_options = { serve: config.serve };
-    server = await startServer(server_options);
+  if (config.serve) {
+    server = await startServer({ serve: config.serve });
     driver_options.url = `https://localhost:${server.port}`;
   }
 

--- a/mochify/lib/server.js
+++ b/mochify/lib/server.js
@@ -15,7 +15,10 @@ async function startServer(options = {}) {
     fs_promises.readFile(path.join(__dirname, '..', 'fixture', 'cert.pem'))
   ]);
 
-  const server = https.createServer({ key, cert }, requestHandler(options));
+  const server = https.createServer(
+    { key, cert },
+    requestHandler(options.serve)
+  );
 
   server.on('error', (err) => {
     process.stderr.write(err.stack || String(err));
@@ -30,8 +33,7 @@ async function startServer(options = {}) {
   };
 }
 
-function requestHandler(options) {
-  const base_path = options.serve || process.cwd();
+function requestHandler(base_path) {
   return async (req, res) => {
     if (req.url === '/') {
       res.writeHead(200);


### PR DESCRIPTION
Simply to have fewer options, I thought we could do just with `--serve $PATH` and remove `--server`.

`--server` is the same as `--serve .`