### PR TITLE
Allow to define "spec" in config and fix package.json

### DIFF
--- a/cli/index.js
+++ b/cli/index.js
@@ -1,8 +1,6 @@
 #!/usr/bin/env node
 'use strict';
 
-const { promisify } = require('util');
-const glob = promisify(require('glob'));
 const yargs = require('yargs/yargs');
 const { hideBin } = require('yargs/helpers');
 const { mochify } = require('@mochify/mochify');
@@ -40,17 +38,14 @@ if (opts['server-option']) {
 }
 
 (async () => {
-  const files = await resolveFiles(opts._);
-  const options = Object.assign({ files }, opts);
+  if (opts._.length) {
+    opts.spec = opts._;
+  }
+  delete opts._;
   try {
-    await mochify(options);
+    await mochify(opts);
   } catch (e) {
     console.error(e.stack);
     process.exitCode = 1;
   }
 })();
-
-async function resolveFiles(patterns) {
-  const matches = await Promise.all(patterns.map((pattern) => glob(pattern)));
-  return matches.reduce((all, match) => all.concat(match), []);
-}

--- a/cli/package.json
+++ b/cli/package.json
@@ -2,6 +2,9 @@
   "name": "@mochify/cli",
   "version": "0.1.0",
   "description": "Run mocha tests in headless browsers from the command line",
+  "bin": {
+    "mochify": "index.js"
+  },
   "main": "index.js",
   "scripts": {
     "test": "echo \"No unit tests yet\"",

--- a/cli/package.json
+++ b/cli/package.json
@@ -28,7 +28,6 @@
   },
   "dependencies": {
     "@mochify/mochify": "^0.1.0",
-    "glob": "^7.1.7",
     "yargs": "^16.2.0"
   },
   "devDependencies": {

--- a/driver-playwright/package.json
+++ b/driver-playwright/package.json
@@ -26,6 +26,7 @@
     "@mochify/mochify": "^0.1.0"
   },
   "files": [
+    "index.html",
     "**/*.js",
     "!**/*.test.js",
     "!test/**",

--- a/driver-puppeteer/package.json
+++ b/driver-puppeteer/package.json
@@ -24,6 +24,7 @@
     "@mochify/mochify": "^0.1.0"
   },
   "files": [
+    "index.html",
     "**/*.js",
     "!**/*.test.js",
     "!test/**",

--- a/mochify/index.js
+++ b/mochify/index.js
@@ -5,6 +5,7 @@ const { loadConfig } = require('./lib/load-config');
 const { setupClient } = require('./lib/setup-client');
 const { createMochaRunner } = require('./lib/mocha-runner');
 const { resolveBundle } = require('./lib/resolve-bundle');
+const { resolveSpec } = require('./lib/resolve-spec');
 const { startServer } = require('./lib/server');
 const { run } = require('./lib/run');
 
@@ -24,8 +25,10 @@ async function mochify(options = {}) {
     driver_options.url = `http://localhost:${server.port}`;
   }
 
+  const files = await resolveSpec(config.spec);
+
   const driver_promise = mochifyDriver(driver_options);
-  const bundler_promise = resolveBundle(config.bundle, config.files);
+  const bundler_promise = resolveBundle(config.bundle, files);
 
   const [driver, bundle, mocha, client] = await Promise.all([
     driver_promise,

--- a/mochify/lib/resolve-spec.js
+++ b/mochify/lib/resolve-spec.js
@@ -1,0 +1,12 @@
+'use strict';
+
+const { promisify } = require('util');
+const glob = promisify(require('glob'));
+
+exports.resolveSpec = resolveSpec;
+
+async function resolveSpec(spec = 'test/**/*.js') {
+  const patterns = Array.isArray(spec) ? spec : [spec];
+  const matches = await Promise.all(patterns.map((pattern) => glob(pattern)));
+  return matches.reduce((all, match) => all.concat(match), []);
+}

--- a/mochify/lib/resolve-spec.test.js
+++ b/mochify/lib/resolve-spec.test.js
@@ -1,0 +1,78 @@
+'use strict';
+
+const proxyquire = require('proxyquire');
+const { assert, sinon } = require('@sinonjs/referee-sinon');
+
+describe('mochify/lib/resolve-spec', () => {
+  let resolveSpec;
+  let glob;
+
+  beforeEach(() => {
+    glob = sinon.fake();
+    ({ resolveSpec } = proxyquire('./resolve-spec', { glob }));
+  });
+
+  it('resolves glob "test/**/*.js" for undefined', async () => {
+    const promise = resolveSpec(undefined);
+    const matches = ['test/this.js', 'test/that.js'];
+
+    assert.calledOnceWith(glob, 'test/**/*.js');
+
+    glob.callback(null, matches);
+
+    await assert.resolves(promise, matches);
+  });
+
+  it('invokes glob with given string pattern', () => {
+    const pattern = 'some/*.js';
+
+    resolveSpec(pattern);
+
+    assert.calledOnceWith(glob, pattern);
+  });
+
+  it('invokes glob concurrently with patterns from array', () => {
+    const patterns = ['a/*.js', 'b/*.js', 'c/*.js'];
+
+    resolveSpec(patterns);
+
+    assert.calledThrice(glob);
+    assert.calledWith(glob, patterns[0]);
+    assert.calledWith(glob, patterns[1]);
+    assert.calledWith(glob, patterns[2]);
+  });
+
+  it('resolves with the result from a single pattern', async () => {
+    const pattern = 'test/**/*.js';
+    const matches = ['test/this.js', 'test/that.js'];
+
+    const promise = resolveSpec(pattern);
+    glob.firstCall.callback(null, matches);
+
+    await assert.resolves(promise, matches);
+  });
+
+  it('resolves with the result from a pattern array', async () => {
+    const patterns = ['a/*.js', 'b/*.js'];
+    const matches_a = ['a/this.js', 'a/that.js'];
+    const matches_b = ['b/more.js'];
+
+    const promise = resolveSpec(patterns);
+    glob.firstCall.callback(null, matches_a);
+    glob.secondCall.callback(null, matches_b);
+
+    await assert.resolves(promise, matches_a.concat(matches_b));
+  });
+
+  it('rejects with error from glob', async () => {
+    const patterns = ['a/*.js', 'b/*.js'];
+    const matches_a = ['a/this.js', 'a/that.js'];
+    const error = new Error('Oh noes!');
+
+    const promise = resolveSpec(patterns);
+    glob.firstCall.callback(null, matches_a);
+    glob.secondCall.callback(error);
+
+    await assert.rejects(promise, error);
+  });
+});

--- a/mochify/package.json
+++ b/mochify/package.json
@@ -30,6 +30,7 @@
     "convert-source-map": "^1.1.3",
     "cosmiconfig": "^7.0.0",
     "execa": "^5.1.1",
+    "glob": "^7.1.7",
     "mime": "^2.5.2",
     "mocha": "^9.0.0",
     "source-map": "^0.5.7",

--- a/mochify/test/bundle.integration.js
+++ b/mochify/test/bundle.integration.js
@@ -10,7 +10,7 @@ describe('bundle', () => {
     await mochify({
       driver: 'jsdom',
       reporter: 'json',
-      files: [],
+      spec: 'unknown-file.js',
       bundle: 'echo \'it("works", function(){});\''
     });
     const output = process.stdout.write.firstCall.args[0];
@@ -24,7 +24,7 @@ describe('bundle', () => {
   it('fails with error from command', async () => {
     const promise = mochify({
       driver: 'jsdom',
-      files: [],
+      spec: 'unknown-file.js',
       bundle: 'false'
     });
 

--- a/mochify/test/spec.integration.js
+++ b/mochify/test/spec.integration.js
@@ -3,14 +3,14 @@
 const { assert, sinon } = require('@sinonjs/referee-sinon');
 const { mochify } = require('..');
 
-describe('files', () => {
-  it('passes files to bundle command', async () => {
+describe('spec', () => {
+  it('passes resolved files to bundle command', async () => {
     sinon.replace(process.stdout, 'write', sinon.fake());
 
     await mochify({
       driver: 'jsdom',
       reporter: 'json',
-      files: [`${__dirname}/fixture/passes.js`],
+      spec: `${__dirname}/fixture/pass*.js`,
       bundle: 'cat'
     });
     const output = process.stdout.write.firstCall.args[0];

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,9 @@
         "glob": "^7.1.7",
         "yargs": "^16.2.0"
       },
+      "bin": {
+        "mochify": "index.js"
+      },
       "devDependencies": {
         "@sinonjs/referee-sinon": "^10.1.0",
         "execa": "^5.1.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,6 @@
       "license": "MIT",
       "dependencies": {
         "@mochify/mochify": "^0.1.0",
-        "glob": "^7.1.7",
         "yargs": "^16.2.0"
       },
       "bin": {
@@ -101,6 +100,7 @@
         "convert-source-map": "^1.1.3",
         "cosmiconfig": "^7.0.0",
         "execa": "^5.1.1",
+        "glob": "^7.1.7",
         "mime": "^2.5.2",
         "mocha": "^9.0.0",
         "source-map": "^0.5.7",
@@ -2094,6 +2094,7 @@
     },
     "node_modules/glob": {
       "version": "7.1.7",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
       "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
       "dependencies": {
         "fs.realpath": "^1.0.0",
@@ -4728,7 +4729,6 @@
         "@mochify/mochify": "^0.1.0",
         "@sinonjs/referee-sinon": "^10.1.0",
         "execa": "^5.1.1",
-        "glob": "^7.1.7",
         "yargs": "^16.2.0"
       }
     },
@@ -4763,6 +4763,7 @@
         "convert-source-map": "^1.1.3",
         "cosmiconfig": "^7.0.0",
         "execa": "^5.1.1",
+        "glob": "^7.1.7",
         "mime": "^2.5.2",
         "mocha": "^9.0.0",
         "proxyquire": "^2.1.3",
@@ -6129,6 +6130,7 @@
     },
     "glob": {
       "version": "7.1.7",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
       "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
       "requires": {
         "fs.realpath": "^1.0.0",


### PR DESCRIPTION
- The cli was missing the bin config.
- The playwright and puppeteer drivers where missing `index.html` in the `files` array.
- It wasn't possible to declare files to include in a config file. Mocha allows to define `spec`, which is what mochify supports now as well.