### PR TITLE
Allow passing through launch options to driver-puppeteer

### DIFF
--- a/driver-puppeteer/README.md
+++ b/driver-puppeteer/README.md
@@ -1,0 +1,41 @@
+# driver-puppeteer
+
+## Usage
+
+Install the package from npm:
+
+```
+npm i @mochify/driver-puppeteer -D
+```
+
+and pass it to the CLI:
+
+```
+mochify --driver puppeteer ...
+```
+
+## Driver options
+
+The driver allows the following options to be set:
+
+### `stderr`
+
+Defines the stream the test output will be written to. Defaults to `process.stderr`
+
+### `ignoreHTTPSErrors`
+
+Whether to ignore HTTPS errors during navigation. Defaults to `false`.
+
+### `executablePath`
+
+The optional path of the Chromium binary to be used. Defaults to `process.env.PUPPETEER_EXECUTABLE_PATH` to work around https://github.com/puppeteer/puppeteer/issues/6957. In case neither the env var nor a value is given, puppeteer uses the bundled Chromium version.
+
+### `args`
+
+An optional array of command line flags to pass to Chromium. `--allow-insecure-localhost` and `--disable-dev-shm-usage` will always be used in addition to the given values.
+
+## Passing through launch options to puppeteer
+
+In addition to the driver options documented above, `driver-puppeteer` allows you to pass through all of puppeteer's other `launchOptions` using the defaults as [described here][launch-options].
+
+[launch-options]: https://pptr.dev/#?product=Puppeteer&version=v10.1.0&show=api-puppeteerlaunchoptions

--- a/driver-puppeteer/index.js
+++ b/driver-puppeteer/index.js
@@ -7,19 +7,19 @@ exports.mochifyDriver = mochifyDriver;
 const default_url = `file:${__dirname}/index.html`;
 
 async function mochifyDriver(options = {}) {
-  const stderr = options.stderr || process.stderr;
+  const { stderr = process.stderr, ...launch_options } = options;
+
+  launch_options.args = [
+    '--allow-insecure-localhost',
+    '--disable-dev-shm-usage',
+    ...(launch_options.args || [])
+  ];
 
   const browser = await driver.launch({
-    ignoreHTTPSErrors: true
-    /*
-    args: [
-      '--allow-insecure-localhost',
-      '--disable-dev-shm-usage',
-      '--no-sandbox',
-      '--disable-setuid-sandbox',
-      '--disable-web-security'
-    ]
-    */
+    ignoreHTTPSErrors: true,
+    // Workaround for https://github.com/puppeteer/puppeteer/issues/6957
+    executablePath: process.env.PUPPETEER_EXECUTABLE_PATH,
+    ...launch_options
   });
 
   const page = await browser.newPage();

--- a/driver-puppeteer/package.json
+++ b/driver-puppeteer/package.json
@@ -23,6 +23,9 @@
   "peerDependencies": {
     "@mochify/mochify": "^0.1.0"
   },
+  "engines": {
+    "node": ">=12.0.0"
+  },
   "files": [
     "index.html",
     "**/*.js",


### PR DESCRIPTION
Resolves #245 

I opted for allowing users to pass through all of the available `launchOptions` to puppeteer while still applying some sane defaults. I have to admit I found writing the docs for this kind of hard, so maybe that's a sign this could be done better?