### PR TITLE
Cater for cases when puppeteer driver args is a string only

### DIFF
--- a/driver-puppeteer/index.js
+++ b/driver-puppeteer/index.js
@@ -12,10 +12,7 @@ async function mochifyDriver(options = {}) {
   // In case this arrives through CLI flags, yargs will pass a string
   // when a single arg is given and an Array of strings when multiple
   // args are given.
-  const extra_args = Array.isArray(launch_options.args)
-    ? launch_options.args
-    : [launch_options.args].filter(Boolean);
-
+  const extra_args = [].concat(launch_options.args).filter(Boolean);
   launch_options.args = [
     '--allow-insecure-localhost',
     '--disable-dev-shm-usage',

--- a/driver-puppeteer/index.js
+++ b/driver-puppeteer/index.js
@@ -9,10 +9,17 @@ const default_url = `file:${__dirname}/index.html`;
 async function mochifyDriver(options = {}) {
   const { stderr = process.stderr, ...launch_options } = options;
 
+  // In case this arrives through CLI flags, yargs will pass a string
+  // when a single arg is given and an Array of strings when multiple
+  // args are given.
+  const extra_args = Array.isArray(launch_options.args)
+    ? launch_options.args
+    : [launch_options.args].filter(Boolean);
+
   launch_options.args = [
     '--allow-insecure-localhost',
     '--disable-dev-shm-usage',
-    ...(launch_options.args || [])
+    ...extra_args
   ];
 
   const browser = await driver.launch({


### PR DESCRIPTION
This is a fixup for #252

It seems that when passing multiple values through the CLI like:

```
mochify --driver-options.args='--allow-chrome-as-root' --driver-options.args='--no-sandbox'
```

`yargs` will pass  `['-allow-chrome-as-root',  '--no-sandbox']` when passing a single value like

```
mochify --driver-options.args='--allow-chrome-as-root'
```

will yield the plain string `'--allow-chrome-as-root'`