### PR TITLE
Import fs/promises in a way that is compatible with Node 12 still

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: ['14.x', '16.x']
+        node-version: ['12.x', '14.x', '16.x']
 
     steps:
       - name: Checkout

--- a/mochify/index.js
+++ b/mochify/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { readFile } = require('fs/promises');
+const { readFile } = require('fs').promises;
 const { loadConfig } = require('./lib/load-config');
 const { setupClient } = require('./lib/setup-client');
 const { createMochaRunner } = require('./lib/mocha-runner');

--- a/mochify/lib/resolve-bundle.js
+++ b/mochify/lib/resolve-bundle.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const fs = require('fs/promises');
+const fs = require('fs').promises;
 const execa = require('execa');
 const { parseArgsStringToArgv } = require('string-argv');
 

--- a/mochify/lib/server.js
+++ b/mochify/lib/server.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const fs = require('fs');
-const fs_promises = require('fs/promises');
+const fs_promises = require('fs').promises;
 const { promisify } = require('util');
 const path = require('path');
 const http = require('http');


### PR DESCRIPTION
From what I understand we still support Node 12 where importing `fs/promises` fails and needs to be `require('fs').promises` instead. See: https://nodejs.org/api/fs.html#fs_promises_api

![image](https://user-images.githubusercontent.com/1662740/132814954-09efdd41-0d26-4f1a-8040-a1044f516bba.png)

Alternatively we could of course also drop support for 12 for the rewrite, but then again I really hope we can get this shipped before its EOL (which is end of April 2022).