### PR TITLE
Forcefully exit 1 in cli when calling mochify throws

### DIFF
--- a/cli/index.js
+++ b/cli/index.js
@@ -46,6 +46,6 @@ if (opts['server-option']) {
     await mochify(opts);
   } catch (e) {
     console.error(e.stack);
-    process.exitCode = 1;
+    process.exit(1);
   }
 })();


### PR DESCRIPTION
Warning: this one is ugly and more of a workaround than a fix. It also does not address the issue for consumers of the API instead of the CLI.

----

I noticed that when you're bad at typing (I heard it happens) and misspell the name of the bundle command, Mochify will hang forever instead of exiting:

```
mochify src/{,**}/*.test.js --config package.json --driver-option.executablePath $(which google-chrome)
```
and
```
  "mochify": {
    "driver": "puppeteer",
    "bundle": "browseryfi",
    "driver_options": {
      "args": ["--no-sandbox", "--allow-chrome-as-root"]
    }
  },
```

will print:

```
Error: Command failed with ENOENT: browseryfi thing1.test.js thing2.test.js ...
spawn browseryfi ENOENT
    at Process.ChildProcess._handle.onexit (internal/child_process.js:268:19)
    at onErrorNT (internal/child_process.js:468:16)
    at processTicksAndRejections (internal/process/task_queues.js:84:21)
```

and then just hang until you Ctrl+C which interestingly just kills the bundler process so that npm will still run posttest hooks and the like.

---

What seems to happen is the following: when calling `mochify` from the cli throws an error and we end up here: https://github.com/mantoni/mochify.js/blob/4f10f3a23bb952ca77a3ffaca669716f553beb73/cli/index.js#L49

the process spawned by `execa` is still alive, seemingly idling forever. Trouble is I really don't know how to make it exit correctly. What I tried is doing something like this:

```js
  let result;
  try {
    result = await execa(cmd, args.concat(files), {
      preferLocal: true
    });
  } catch (err) {
    result.cancel(); // cannot call `cancel` on undefined
    throw err;
  }
```

I also looked at the source code of `lint-staged`: https://github.com/okonet/lint-staged/blob/101ad5ea21a5cab51a9a2a9d4701defe26e346ca/lib/resolveTaskFn.js#L103-L105 but it seems they do the same thing (potentially running into the same issue).