### PR TITLE
Ensure bundling ran successfully before instantiating driver

### DIFF
--- a/mochify/index.js
+++ b/mochify/index.js
@@ -26,13 +26,10 @@ async function mochify(options = {}) {
   }
 
   const files = await resolveSpec(config.spec);
+  const bundle = await resolveBundle(config.bundle, files);
 
-  const driver_promise = mochifyDriver(driver_options);
-  const bundler_promise = resolveBundle(config.bundle, files);
-
-  const [driver, bundle, mocha, client] = await Promise.all([
-    driver_promise,
-    bundler_promise,
+  const [driver, mocha, client] = await Promise.all([
+    mochifyDriver(driver_options),
     readFile(require.resolve('mocha/mocha.js'), 'utf8'),
     readFile(require.resolve('./client'), 'utf8')
   ]);


### PR DESCRIPTION
As described in #258 a failed bundling would currently cause Mochify to never exit (when using `driver-puppeteer` at least).

This seems to happen because in that case noone ever calls `end` on the driver, leaving `puppeteer` idling. To work around this, we can make sure bundling worked properly before instantiating the driver so we can make sure it can always be closed.

N.B.: In case you are wondering how it would look like if bundling and driver instantiation would still happen in "parallel": https://github.com/mantoni/mochify.js/commit/279086018643a9f98b54f975607ba3aeb4514217 - I found it nicer doing it serially as it requires a lot less control flow logic.