### PR TITLE
Shutdown on errors

### DIFF
--- a/driver-jsdom/index.js
+++ b/driver-jsdom/index.js
@@ -38,9 +38,9 @@ function mochifyDriver(options = {}) {
     return Promise.resolve(window.eval(script));
   }
 
-  return {
+  return Promise.resolve({
     evaluate,
     evaluateReturn: evaluate,
     end
-  };
+  });
 }


### PR DESCRIPTION
This is an alternative implementation of #259 which retains parallel execution of the driver and the bundler. These are the two sub processes that may take a while, so I would prefer to not run them sequentially.

One of the integration tests highlighted that the `driver-jsdom` doesn't return a promise, which this fixes as well.