### PR TITLE
Return exit code from main API method instead of setting it

### DIFF
--- a/cli/index.js
+++ b/cli/index.js
@@ -43,7 +43,8 @@ if (opts['server-option']) {
   }
   delete opts._;
   try {
-    await mochify(opts);
+    const { exit_code } = await mochify(opts);
+    process.exitCode = exit_code;
   } catch (e) {
     console.error(e.stack);
     process.exitCode = 1;

--- a/mochify/index.js
+++ b/mochify/index.js
@@ -59,9 +59,7 @@ async function mochify(options = {}) {
     await shutdown(driver, server);
   }
 
-  if (exit_code) {
-    process.exitCode = exit_code;
-  }
+  return { exit_code };
 }
 
 function resolveMochifyDriver(name = 'puppeteer') {


### PR DESCRIPTION
This picks up https://github.com/mantoni/mochify.js/pull/259#issuecomment-916875460

Technically this is a breaking change, so maybe you want to wait with merging this before we do a `0.3.0`?