### PR TITLE
Do not assume availability of default driver, prevent accidental fall back to wrong modules

### DIFF
--- a/cli/test/config.integration.js
+++ b/cli/test/config.integration.js
@@ -30,7 +30,7 @@ describe('config', () => {
   it('overrides config with command line option', async () => {
     const result = await execa(
       '../../index.js',
-      ['--reporter', 'tap', 'passes.js'],
+      ['--reporter', 'tap', '--driver', 'jsdom', 'passes.js'],
       {
         cwd: path.join(__dirname, 'fixture')
       }

--- a/cli/test/fixture/custom.config.yaml
+++ b/cli/test/fixture/custom.config.yaml
@@ -1,2 +1,3 @@
 # Config
 reporter: tap
+driver: jsdom

--- a/cli/test/fixture/mochify.config.js
+++ b/cli/test/fixture/mochify.config.js
@@ -1,3 +1,4 @@
 'use strict';
 
 exports.reporter = 'json';
+exports.driver = 'jsdom';

--- a/mochify/index.js
+++ b/mochify/index.js
@@ -64,18 +64,30 @@ async function mochify(options = {}) {
 
 function resolveMochifyDriver(name) {
   if (!name) {
-    throw new Error('Specifying a driver option is required.');
+    throw new Error(
+      'Specifying a driver option is required. Mochify drivers need to be installed separately from the API or the CLI.'
+    );
   }
+
+  let driverModule;
   try {
     // eslint-disable-next-line node/global-require
-    return require(`@mochify/driver-${name}`);
+    driverModule = require(`@mochify/driver-${name}`);
   } catch (err) {
     if (err.code !== 'MODULE_NOT_FOUND') {
       throw err;
     }
     // eslint-disable-next-line node/global-require
-    return require(name);
+    driverModule = require(name);
   }
+
+  if (!driverModule || typeof driverModule.mochifyDriver !== 'function') {
+    throw new Error(
+      `Expected driver "${name}" to export a "mochifyDriver(options)" method. Did you forget to install the "@mochify/driver-${name}" package?`
+    );
+  }
+
+  return driverModule;
 }
 
 async function shutdown(driver, server) {

--- a/mochify/index.js
+++ b/mochify/index.js
@@ -62,7 +62,10 @@ async function mochify(options = {}) {
   return { exit_code };
 }
 
-function resolveMochifyDriver(name = 'puppeteer') {
+function resolveMochifyDriver(name) {
+  if (!name) {
+    throw new Error('Specifying a driver option is required.');
+  }
   try {
     // eslint-disable-next-line node/global-require
     return require(`@mochify/driver-${name}`);


### PR DESCRIPTION
This PR addresses two issues:

I noticed I could run tests when not specifying any `driver`. I'm not sure if we want this as installing `@mochify/cli` or `@mochfiy/mochify` does not provide any driver implementation themselves and consumers would see a message about how a module could not be found when trying to run it, probably thinking this is a bug. Instead we can provide a clear error message about it.

The logic I implemented in #253 has one really awful flaw: Assuming you try passing `jsdom` as the driver without having installed it (whre it = `@mochify/driver-jsdom`), the logic would fall back to requiring `jsdom` which might be installed or resolvable because it's used by something else and then Mochify would try to use the main export of the `jsdom` module as a driver. I don't even want to imagine the confusion caused by the error messages happening here :sweat_smile: . To work around this, a check if the export matches the expected interface is added.