### PR TITLE
Run playwright integration tests in Firefox

### DIFF
--- a/cli/test/playwright.integration.js
+++ b/cli/test/playwright.integration.js
@@ -9,7 +9,7 @@ describe('playwright', () => {
     try {
       return await execa(
         '../../index.js',
-        ['--driver', 'playwright', '--driver-option.engine', 'chromium', file],
+        ['--driver', 'playwright', '--driver-option.engine', 'firefox', file],
         {
           cwd: path.join(__dirname, 'fixture')
         }


### PR DESCRIPTION
Picking up: https://github.com/mantoni/mochify.js/pull/241/files/ca46f4857c81b0473a406ef5129b0d69e675bad5#r680548654

As this worked on first attempt (i.e. as documented) I'm not sure why it failed back then? Maybe it's because of 51db9e2aabe90a09a3a6ca3aaeb16a011bdcd732 (I did notice that Firefox was significantly slower than Chromium when adding the initial version of the driver so it would make sense)?

