### PR TITLE
Rewrite: Add help and example content for CLI module

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -1,0 +1,64 @@
+# cli
+
+## Usage
+
+Install the package from npm:
+
+```
+npm i @mochify/cli -D
+```
+
+which will make `mochify` command available:
+
+```
+mochify [options] <spec...>
+```
+
+## Options
+
+The Mochify CLI can pick up configuration from files or CLI flags.
+File config can be provided through `package.json`, JSON or YAML files.
+In case an option is present in both the config file and as a CLI flag, the flag takes precedence.
+Refer to the documentation of `@mochify/mochify` for available configuration options.
+
+### `--config`, `-C`
+
+The config file to use.
+Defaults to `package.json` where a top-level `mochify` key can hold configuration.
+
+### `--driver`, `-D`
+
+The driver to use for running the tests.
+Drivers published to the @mochify scope can be referenced using their suffix only (e.g. `puppeteer`), third-party or local drivers will need to use the full package name or file path.
+Drivers need to be installed separately from the Mochify CLI.
+
+### `--driver-option`
+
+Free form options to pass to the driver in use. Pass an arbitrary number of options using `--driver-option.foo 1 --driver-option.bar 2`. Refer to the documentation of the driver in use for available options.
+
+### `--reporter`, `-R`
+
+The Mocha reporter to use.
+Right now, only reporters that are included with Mocha itself can be used.
+
+### `--bundle`, `-B`
+
+The command used for bundling the given spec.
+The called executable is expected to be installed by the consumer.
+In case no bundle command is given and --esm is not used, spec files will be concatenated instead of bundling before running the test suite.
+The command will receive the resolved value of <spec>.
+
+### `--esm`
+
+Run a local web server and inject all files in the spec as `<script type="module">` instead of bundling.
+The server serves the contents of the current working directory unless `--serve` is given, in which case the contents of the given location will be served instead.
+
+### `--serve`, `-S`
+
+Run the tests in the context of a local web server.
+Files in the given directory will be served as static assets.
+
+### `--server-option`
+
+Options to pass to the server in case `--serve` or `--esm` is being used.
+Currently only `--server-option.port` for passing the port to use is supported.

--- a/cli/README.md
+++ b/cli/README.md
@@ -17,14 +17,16 @@ mochify [options] <spec...>
 ## Options
 
 The Mochify CLI can pick up configuration from files or CLI flags.
-File config can be provided through `package.json`, JSON or YAML files.
+File config can be provided through `package.json` or in JavaScript, JSON or YAML files and is resolved using the [default lookup mechanism specified by `cosmiconfig`][cosmiconfig].
+For example, you could either put configuration in a top-level `mochify` key in package.json for static values or a `mochify.config.js` for dynamic ones, and have them being picked up automatically.
 In case an option is present in both the config file and as a CLI flag, the flag takes precedence.
 Refer to the documentation of `@mochify/mochify` for available configuration options.
 
+[cosmiconfig]: https://github.com/davidtheclark/cosmiconfig#explorersearch
+
 ### `--config`, `-C`
 
-The config file to use.
-Defaults to `package.json` where a top-level `mochify` key can hold configuration.
+Override the default lookup and use the file as the source of configuration.
 
 ### `--driver`, `-D`
 
@@ -46,7 +48,7 @@ Right now, only reporters that are included with Mocha itself can be used.
 The command used for bundling the given spec.
 The called executable is expected to be installed by the consumer.
 In case no bundle command is given and --esm is not used, spec files will be concatenated instead of bundling before running the test suite.
-The command will receive the resolved value of <spec>.
+The command will receive the resolved value of `<spec...>`.
 
 ### `--esm`
 

--- a/cli/index.js
+++ b/cli/index.js
@@ -9,8 +9,8 @@ const opts = yargs(hideBin(process.argv))
   .usage(
     '$0 [options] <spec...>',
     'Run Mocha tests in real browsers.',
-    (local) => {
-      local
+    (cmd) => {
+      cmd
         .example(
           '$0 --driver puppeteer --bundle browserify "./src/**/*.test.js" ',
           'Bundle all files matching the given spec using browserify and run them using @mochify/driver-puppeteer.'
@@ -21,11 +21,11 @@ const opts = yargs(hideBin(process.argv))
         )
         .example(
           '$0 "./src/**/*.test.js" ',
-          'Run all tests matching the given spec using the configuration from package.json'
+          'Run all tests matching the given spec using the default configuration lookup.'
         )
         .example(
-          '$0 --config .mochifyrc.yml "./src/**/*.test.js" ',
-          'Run all tests matching the given spec using the configuration from .mochifyrc.yml'
+          '$0 --config mochify.webdriver.js "./src/**/*.test.js" ',
+          'Run all tests matching the given spec using the configuration from mochify.webdriver.js.'
         )
         .epilogue(
           `Mochify Resources:
@@ -37,48 +37,47 @@ GitHub: https://github.com/mantoni/mochify.js`
     alias: 'C',
     type: 'string',
     group: 'Options:',
-    describe: 'The config file to use (defaults to "package.json")'
+    describe: 'Specify a config file, skipping default lookup'
   })
   .option('driver', {
     alias: 'D',
     type: 'string',
     group: 'Options:',
-    describe: 'The driver module to use'
+    describe: 'Specify the driver module'
   })
   .option('driver-option', {
     type: 'object',
     group: 'Options:',
-    describe: 'Options to pass to the driver'
+    describe: 'Pass options to the driver'
   })
   .option('reporter', {
     alias: 'R',
     type: 'string',
     group: 'Options:',
-    describe: 'Specify Mocha reporter to use'
+    describe: 'Specify the Mocha reporter'
   })
   .option('bundle', {
     alias: 'B',
     type: 'string',
     group: 'Options:',
-    describe: 'Command used for bundling the given spec'
+    describe: 'Bundle the resolved spec using the given command'
   })
   .option('esm', {
     type: 'boolean',
     group: 'Options:',
-    describe: 'Run a local server and inject spec files as ES modules'
+    describe: 'Run a local web server, inject spec files as ES modules'
   })
   .option('serve', {
     alias: 'S',
     type: 'string',
     group: 'Options:',
     describe:
-      'Run tests in the context of a local web server and serve the given directory'
+      'Run tests in the context of a local web server, serve the given directory'
   })
   .option('server-option', {
     type: 'object',
     group: 'Options:',
-    describe:
-      'Options to pass to the server in case --serve or --esm is being used'
+    describe: 'Pass options to the server (requires --serve or --esm)'
   })
   .updateStrings({
     'Options:': 'Other:'

--- a/cli/index.js
+++ b/cli/index.js
@@ -6,31 +6,82 @@ const { hideBin } = require('yargs/helpers');
 const { mochify } = require('@mochify/mochify');
 
 const opts = yargs(hideBin(process.argv))
+  .usage(
+    '$0 [options] <spec...>',
+    'Run Mocha tests using Mochify.',
+    (local) => {
+      local
+        .example(
+          '$0 --driver puppeteer --bundle browserify "./src/**/*.test.js" ',
+          'Bundle all files matching the given spec using browserify and run them using @mochify/driver-puppeteer.'
+        )
+        .example(
+          '$0 --config package.json "./src/**/*.test.js" ',
+          'Run all tests matching the given spec using the configuration from package.json\'s "mochify" key.'
+        )
+        .example(
+          '$0 --esm --reporter dot "./src/**/*.test.js" ',
+          'Run all tests matching the given spec as ES modules and use the "dot" reporter for output.'
+        );
+    }
+  )
   .option('config', {
-    type: 'string'
+    alias: 'C',
+    type: 'string',
+    group: 'Options:',
+    describe:
+      'The config file to use. In case `package.json` is given, the configuration is expected to be stored in a top-level "mochify" key. In case an option is present in both the config file and as a CLI flag, the flag takes precedence. Refer to the documentation of `@mochify/mochify` for available configuration options.'
   })
   .option('driver', {
-    type: 'string'
+    alias: 'D',
+    type: 'string',
+    group: 'Options:',
+    describe:
+      'The driver to use for running the tests. Drivers published to the @mochify scope can be referenced using their suffix only (e.g. `puppeteer`), third-party or local drivers will need to use the full package name or file path. Drivers need to be installed separately from the Mochify CLI.'
   })
   .option('driver-option', {
-    type: 'object'
+    type: 'object',
+    group: 'Options:',
+    describe:
+      'Free form options to pass to the driver in use. Pass an arbitrary number of options using `--driver-option.foo 1 --driver-option.bar 2`. Refer to the documentation of the driver in use for available options.'
   })
   .option('reporter', {
     alias: 'R',
-    type: 'string'
+    type: 'string',
+    group: 'Options:',
+    describe:
+      'The Mocha reporter to use. Right now, only reporters that are included with Mocha itself can be used.'
   })
   .option('bundle', {
-    type: 'string'
+    alias: 'B',
+    type: 'string',
+    group: 'Options:',
+    describe:
+      'The command used for bundling the given spec. The called executable is expected to be installed by the consumer. In case no bundle command is given and --esm is not used, spec files will be concatenated instead of bundling before running the test suite. The command will be passed the resolved value of <spec>.'
   })
   .option('esm', {
-    type: 'boolean'
+    type: 'boolean',
+    group: 'Options:',
+    describe:
+      'Run a local web server and inject all files in the spec as <script type="module"> instead of bundling. The server serves the contents of the current working directory unless `--serve` is given, in which case the contents of the given location will be served instead.'
   })
   .option('serve', {
-    type: 'string'
+    alias: 'S',
+    type: 'string',
+    group: 'Options:',
+    describe:
+      'Run the tests in the context of a local web server. Files in the given directory will be served as static assets.'
   })
   .option('server-option', {
-    type: 'object'
+    type: 'object',
+    group: 'Options:',
+    describe:
+      'Options to pass to the server in case `--serve` or `--esm` is being used. Currently only `--server-option.port` for passing the port to use is supported.'
   })
+  .updateStrings({
+    'Options:': 'Other:'
+  })
+  .conflicts('bundle', 'esm')
   .parse();
 
 if (opts['driver-option']) {


### PR DESCRIPTION
This is a first pass at adding some content and structure to the output of `mochify --help`. Right now, this is relatively wordy (maybe a little too wordy) as it's the only documentation around, I think it should be possible to reduce the amount of inline docs over time (moving it to `@mochify/mochify`).