### PR TITLE
Unnest yargs definition to restore argv._

### DIFF
--- a/cli/index.js
+++ b/cli/index.js
@@ -6,33 +6,7 @@ const { hideBin } = require('yargs/helpers');
 const { mochify } = require('@mochify/mochify');
 
 const opts = yargs(hideBin(process.argv))
-  .usage(
-    '$0 [options] <spec...>',
-    'Run Mocha tests in real browsers.',
-    (cmd) => {
-      cmd
-        .example(
-          '$0 --driver puppeteer --bundle browserify "./src/**/*.test.js" ',
-          'Bundle all files matching the given spec using browserify and run them using @mochify/driver-puppeteer.'
-        )
-        .example(
-          '$0 --esm --reporter dot --driver puppeteer "./src/**/*.test.js" ',
-          'Run all tests matching the given spec as ES modules in puppeteer and use the "dot" reporter for output.'
-        )
-        .example(
-          '$0 "./src/**/*.test.js" ',
-          'Run all tests matching the given spec using the default configuration lookup.'
-        )
-        .example(
-          '$0 --config mochify.webdriver.js "./src/**/*.test.js" ',
-          'Run all tests matching the given spec using the configuration from mochify.webdriver.js.'
-        )
-        .epilogue(
-          `Mochify Resources:
-GitHub: https://github.com/mantoni/mochify.js`
-        );
-    }
-  )
+  .usage('$0 [config] <spec...>')
   .option('config', {
     alias: 'C',
     type: 'string',
@@ -82,6 +56,26 @@ GitHub: https://github.com/mantoni/mochify.js`
   .updateStrings({
     'Options:': 'Other:'
   })
+  .example(
+    '$0 --driver puppeteer --bundle browserify "./src/**/*.test.js" ',
+    'Bundle all files matching the given spec using browserify and run them using @mochify/driver-puppeteer.'
+  )
+  .example(
+    '$0 --esm --reporter dot --driver puppeteer "./src/**/*.test.js" ',
+    'Run all tests matching the given spec as ES modules in puppeteer and use the "dot" reporter for output.'
+  )
+  .example(
+    '$0 "./src/**/*.test.js" ',
+    'Run all tests matching the given spec using the default configuration lookup.'
+  )
+  .example(
+    '$0 --config mochify.webdriver.js "./src/**/*.test.js" ',
+    'Run all tests matching the given spec using the configuration from mochify.webdriver.js.'
+  )
+  .epilogue(
+    `Mochify Resources:
+GitHub: https://github.com/mantoni/mochify.js`
+  )
   .wrap(process.stdout.columns ? Math.min(process.stdout.columns, 80) : 80)
   .parse();
 


### PR DESCRIPTION
It seems #267 introduced a subtle breakage: it seems yargs now somehow parses `spec` by itself, rendering the logic around `opts._` unneccessary. This would be fine all by itself (we could remove https://github.com/mantoni/mochify.js/blob/b407d82bda319251e7dcda039bbbd4a273d6224b/cli/index.js#L96-L98) until #268 enters the stage: when handling positional arguments yargs will just eat `-` without any further notice: https://github.com/yargs/yargs/issues/1312

Why did I introduce the nested command in #267 the first place? It seems that if you pass a second argument to `.usage()` yargs will somehow not display `example`, `epilogue` and such unless you start attaching it to the child instance, which means this PR needs to drop the command description again. I don't know if this is a bug in yargs, I am doing something wrong or something completely different is going on.

This is also the reason the tests for #269 are currently broken (after I rebased against `rewrite` that is).

Sorry if this is terribly confusing.