### PR TITLE
Allow driver option to be a module on API level

### DIFF
--- a/mochify/index.js
+++ b/mochify/index.js
@@ -73,22 +73,27 @@ async function mochify(options = {}) {
   return { exit_code };
 }
 
-function resolveMochifyDriver(name) {
-  let driverModule;
-  try {
-    // eslint-disable-next-line node/global-require
-    driverModule = require(`@mochify/driver-${name}`);
-  } catch (err) {
-    if (err.code !== 'MODULE_NOT_FOUND') {
-      throw err;
+function resolveMochifyDriver(driver) {
+  let driverModule = driver;
+  let driverReference = 'given driver object';
+  if (typeof driver === 'string') {
+    try {
+      // eslint-disable-next-line node/global-require
+      driverModule = require(`@mochify/driver-${driver}`);
+    } catch (err) {
+      if (err.code !== 'MODULE_NOT_FOUND') {
+        throw err;
+      }
+      // eslint-disable-next-line node/global-require
+      driverModule = require(driver);
     }
-    // eslint-disable-next-line node/global-require
-    driverModule = require(name);
+    driverReference = `driver "${driver}"`;
   }
 
   if (!driverModule || typeof driverModule.mochifyDriver !== 'function') {
     throw new Error(
-      `Expected driver "${name}" to export a "mochifyDriver(options)" method. Did you forget to install the "@mochify/driver-${name}" package?`
+      `Expected ${driverReference} to export a "mochifyDriver(options)" method. ` +
+        `Did you forget to install the "@mochify/driver-${driver}" package?`
     );
   }
 

--- a/mochify/index.js
+++ b/mochify/index.js
@@ -7,6 +7,7 @@ const { setupClient } = require('./lib/setup-client');
 const { createMochaRunner } = require('./lib/mocha-runner');
 const { resolveBundle } = require('./lib/resolve-bundle');
 const { resolveSpec } = require('./lib/resolve-spec');
+const { resolveMochifyDriver } = require('./lib/mochify-driver');
 const { startServer } = require('./lib/server');
 const { run } = require('./lib/run');
 
@@ -71,33 +72,6 @@ async function mochify(options = {}) {
   }
 
   return { exit_code };
-}
-
-function resolveMochifyDriver(driver) {
-  let driverModule = driver;
-  let driverReference = 'given driver object';
-  if (typeof driver === 'string') {
-    try {
-      // eslint-disable-next-line node/global-require
-      driverModule = require(`@mochify/driver-${driver}`);
-    } catch (err) {
-      if (err.code !== 'MODULE_NOT_FOUND') {
-        throw err;
-      }
-      // eslint-disable-next-line node/global-require
-      driverModule = require(driver);
-    }
-    driverReference = `driver "${driver}"`;
-  }
-
-  if (!driverModule || typeof driverModule.mochifyDriver !== 'function') {
-    throw new Error(
-      `Expected ${driverReference} to export a "mochifyDriver(options)" method. ` +
-        `Did you forget to install the "@mochify/driver-${driver}" package?`
-    );
-  }
-
-  return driverModule;
 }
 
 async function shutdown(driver, server) {

--- a/mochify/lib/mochify-driver.js
+++ b/mochify/lib/mochify-driver.js
@@ -1,0 +1,31 @@
+'use strict';
+
+exports.resolveMochifyDriver = resolveMochifyDriver;
+
+function resolveMochifyDriver(driver) {
+  let driverModule = driver;
+  let driverReference = 'given driver object';
+  if (typeof driver === 'string') {
+    try {
+      // eslint-disable-next-line node/global-require
+      driverModule = require(`@mochify/driver-${driver}`);
+    } catch (err) {
+      if (err.code !== 'MODULE_NOT_FOUND') {
+        throw err;
+      }
+      // eslint-disable-next-line node/global-require
+      driverModule = require(driver);
+    }
+    driverReference = `driver "${driver}"`;
+  }
+
+  if (!driverModule || typeof driverModule.mochifyDriver !== 'function') {
+    let message = `Expected ${driverReference} to export a "mochifyDriver(options)" method.`;
+    if (typeof driver === 'string') {
+      message += ` Did you forget to install the "@mochify/driver-${driver}" package?`;
+    }
+    throw new TypeError(message);
+  }
+
+  return driverModule;
+}

--- a/mochify/lib/mochify-driver.test.js
+++ b/mochify/lib/mochify-driver.test.js
@@ -1,0 +1,108 @@
+'use strict';
+
+const proxyquire = require('proxyquire');
+const { assert } = require('@sinonjs/referee-sinon');
+
+describe('mochify/lib/mochify-driver', () => {
+  function requireResolveMochifyDriver(stubs = {}) {
+    const { resolveMochifyDriver } = proxyquire('./mochify-driver', stubs);
+    return resolveMochifyDriver;
+  }
+
+  it('passes through valid driver instances', () => {
+    const resolveMochifyDriver = requireResolveMochifyDriver();
+    const ad_hoc_driver = {
+      mochifyDriver(_options) {},
+      __im_a_test_driver: true
+    };
+    const result = resolveMochifyDriver(ad_hoc_driver);
+    assert.isTrue(result.__im_a_test_driver);
+  });
+
+  it('rejects malformed driver instances', () => {
+    const resolveMochifyDriver = requireResolveMochifyDriver();
+    const bad_ad_hoc_driver = {
+      mochyfiDrive(_options) {}
+    };
+    assert.exception(
+      () => {
+        resolveMochifyDriver(bad_ad_hoc_driver);
+      },
+      {
+        name: 'TypeError',
+        message: 'given driver object'
+      }
+    );
+  });
+
+  it('rejects undefined with a helpful error message', () => {
+    const resolveMochifyDriver = requireResolveMochifyDriver();
+    assert.exception(
+      () => {
+        resolveMochifyDriver();
+      },
+      {
+        name: 'TypeError',
+        message: 'given driver object'
+      }
+    );
+  });
+
+  it('allows shortcuts for @mochify scoped drivers', () => {
+    const resolveMochifyDriver = requireResolveMochifyDriver({
+      '@mochify/driver-test': {
+        mochifyDriver(_options) {},
+        __im_a_test_driver: true,
+        '@runtimeGlobal': true,
+        '@noCallThru': true
+      }
+    });
+    const result = resolveMochifyDriver('test');
+    assert.isTrue(result.__im_a_test_driver);
+  });
+
+  it('falls back to loading non-scoped packages', () => {
+    const resolveMochifyDriver = requireResolveMochifyDriver({
+      'test-driver': {
+        mochifyDriver(_options) {},
+        __im_a_test_driver: true,
+        '@runtimeGlobal': true,
+        '@noCallThru': true
+      }
+    });
+    const result = resolveMochifyDriver('test-driver');
+    assert.isTrue(result.__im_a_test_driver);
+  });
+
+  it('rejects malformed packages referenced as a string', () => {
+    const resolveMochifyDriver = requireResolveMochifyDriver({
+      'test-driver': {
+        mochyfiDrive(_options) {},
+        '@runtimeGlobal': true,
+        '@noCallThru': true
+      }
+    });
+    assert.exception(
+      () => {
+        resolveMochifyDriver('test-driver');
+      },
+      {
+        name: 'TypeError',
+        message: 'driver "test-driver"'
+      }
+    );
+  });
+
+  it('rejects non-existent packages referenced as a string', () => {
+    const resolveMochifyDriver = requireResolveMochifyDriver();
+    assert.exception(
+      () => {
+        resolveMochifyDriver('test-driver');
+      },
+      {
+        name: 'Error',
+        message: 'Cannot find module'
+      }
+    );
+  });
+});


### PR DESCRIPTION
Consumers of the API module might want to pass in a custom (?) driver module instead of having to rely on Mochify to do the resolution:

```js
mochify({
  driver: require('./my-driver-thing'),
  ...other
})
```

---

While this might look simple in the above snippet, there is one thing I am not sure about: does this mean that you're using a `.js` config file, you could require the driver in there and pass it down? In case yes, do we want that or should config stay rather dumb?