### PR TITLE
Wrap webdriver script content in IIFE, removing need for evaluateReturn

### DIFF
--- a/driver-jsdom/index.js
+++ b/driver-jsdom/index.js
@@ -47,7 +47,6 @@ function mochifyDriver(options = {}) {
 
   return Promise.resolve({
     evaluate,
-    evaluateReturn: evaluate,
     end
   });
 }

--- a/driver-playwright/index.js
+++ b/driver-playwright/index.js
@@ -56,7 +56,6 @@ async function mochifyDriver(options = {}) {
 
   return {
     evaluate,
-    evaluateReturn: evaluate,
     end
   };
 }

--- a/driver-puppeteer/index.js
+++ b/driver-puppeteer/index.js
@@ -65,7 +65,6 @@ async function mochifyDriver(options = {}) {
 
   return {
     evaluate,
-    evaluateReturn: evaluate,
     end
   };
 }

--- a/driver-webdriver/index.js
+++ b/driver-webdriver/index.js
@@ -29,8 +29,11 @@ async function mochifyDriver(options = {}) {
 
   return {
     evaluate: (script) =>
-      client.executeScript(
-        `return (function () { var __mochify_return_value = ${script}; return __mochify_return_value; })()`,
+      client.executeAsyncScript(
+        `
+          var __mochify_return_value = ${script};
+          arguments[arguments.length - 1](__mochify_return_value)
+        `,
         []
       ),
     end: () => client.deleteSession()

--- a/driver-webdriver/index.js
+++ b/driver-webdriver/index.js
@@ -28,8 +28,11 @@ async function mochifyDriver(options = {}) {
   await client.navigateTo(url || default_url);
 
   return {
-    evaluate: (script) => client.executeScript(script, []),
-    evaluateReturn: (script) => client.executeScript(`return ${script}`, []),
+    evaluate: (script) =>
+      client.executeScript(
+        `return (function () { var __mochify_return_value = ${script}; return __mochify_return_value; })()`,
+        []
+      ),
     end: () => client.deleteSession()
   };
 }

--- a/mochify/client.js
+++ b/mochify/client.js
@@ -3,162 +3,160 @@
   object-shorthand, prefer-template*/
 'use strict';
 
-(function () {
-  var constants = Mocha.Runner.constants;
+var constants = Mocha.Runner.constants;
 
-  var error_keys = [
-    'name',
-    'message',
-    'stack',
-    'code',
-    'expected',
-    'actual',
-    'operator'
-  ];
-  var test_keys = [
-    'title',
-    'type',
-    'state',
-    'pending',
-    'duration',
-    'timedOut',
-    'speed',
-    '_slow',
-    '_currentRetry'
-  ];
+var error_keys = [
+  'name',
+  'message',
+  'stack',
+  'code',
+  'expected',
+  'actual',
+  'operator'
+];
+var test_keys = [
+  'title',
+  'type',
+  'state',
+  'pending',
+  'duration',
+  'timedOut',
+  'speed',
+  '_slow',
+  '_currentRetry'
+];
 
-  var hasOwnProperty = Object.prototype.hasOwnProperty;
-  var slice = Array.prototype.slice;
+var hasOwnProperty = Object.prototype.hasOwnProperty;
+var slice = Array.prototype.slice;
 
-  function copy(keys, from, to) {
-    keys.forEach(function (key) {
-      if (hasOwnProperty.call(from, key)) {
-        to[key] = from[key];
-      }
-    });
-  }
-
-  var queue = [];
-
-  function pollEvents() {
-    if (!queue.length) {
-      return null;
-    }
-    var events = queue.slice();
-    queue.length = 0;
-    return events;
-  }
-
-  function write(event, data) {
-    queue.push([event, data]);
-  }
-
-  function getTestData(test) {
-    var json = {
-      _fullTitle: test.fullTitle(),
-      _titlePath: test.titlePath()
-    };
-    copy(test_keys, test, json);
-    return json;
-  }
-
-  function forward(runner, event, processor) {
-    runner.on(event, function (object, err) {
-      write(event, processor(object, err));
-    });
-  }
-
-  function MochifyReporter(runner) {
-    var stats = runner.stats;
-
-    forward(runner, constants.EVENT_RUN_BEGIN, function () {
-      return {
-        start: stats.start.toISOString()
-      };
-    });
-
-    forward(runner, constants.EVENT_RUN_END, function () {
-      return {
-        end: stats.end.toISOString(),
-        duration: stats.duration
-      };
-    });
-
-    forward(runner, constants.EVENT_SUITE_BEGIN, function (suite) {
-      return {
-        root: suite.root,
-        title: suite.title,
-        pending: suite.pending,
-        delayed: suite.delayed
-      };
-    });
-
-    forward(runner, constants.EVENT_SUITE_END, function () {
-      return {};
-    });
-    forward(runner, constants.EVENT_DELAY_BEGIN, function () {
-      return {};
-    });
-    forward(runner, constants.EVENT_DELAY_END, function () {
-      return {};
-    });
-
-    forward(runner, constants.EVENT_TEST_PASS, getTestData);
-    forward(runner, constants.EVENT_TEST_PENDING, getTestData);
-    forward(runner, constants.EVENT_TEST_FAIL, function (test, err) {
-      var json = getTestData(test);
-      json.err = {};
-      copy(error_keys, err, json.err);
-      return json;
-    });
-    forward(runner, constants.EVENT_TEST_END, getTestData);
-  }
-
-  mocha.reporter(MochifyReporter);
-  mocha.ui(/* MOCHIFY_UI */);
-  mocha.timeout(/* MOCHIFY_TIMEOUT */);
-
-  // Workaround for https://github.com/mozilla/geckodriver/issues/1798
-  if (typeof globalThis !== 'undefined' && globalThis !== window) {
-    // Register globals on window. Mocha uses globalThis, if defined.
-    window.mocha = mocha;
-    mocha.suite.emit('pre-require', window, null, mocha);
-  }
-
-  mocha.mochify_pollEvents = pollEvents;
-
-  var chunks = [];
-  mocha.mochify_receive = function (chunk) {
-    chunks.push(chunk);
-  };
-  mocha.mochify_run = function () {
-    // Inject script
-    var s = document.createElement('script');
-    s.type = 'text/javascript';
-    s.textContent = chunks.join('');
-    document.body.appendChild(s);
-    // Run mocha
-    mocha.run(function (code) {
-      if (typeof __coverage__ !== 'undefined') {
-        write('mochify.coverage', window.__coverage__);
-      }
-      write('mochify.callback', { code: code });
-    });
-  };
-
-  ['debug', 'log', 'info', 'warn', 'error'].forEach(function (name) {
-    if (console[name]) {
-      console[name] = function () {
-        write('console.' + name, slice.call(arguments));
-      };
+function copy(keys, from, to) {
+  keys.forEach(function (key) {
+    if (hasOwnProperty.call(from, key)) {
+      to[key] = from[key];
     }
   });
+}
 
-  window.onerror = function (msg, file, line, column, err) {
-    if (err) {
-      console.error(err.stack);
-    } else {
-      console.error(msg + '\n    at ' + file + ':' + line + ':' + column);
-    }
+var queue = [];
+
+function pollEvents() {
+  if (!queue.length) {
+    return null;
+  }
+  var events = queue.slice();
+  queue.length = 0;
+  return events;
+}
+
+function write(event, data) {
+  queue.push([event, data]);
+}
+
+function getTestData(test) {
+  var json = {
+    _fullTitle: test.fullTitle(),
+    _titlePath: test.titlePath()
   };
-})();
+  copy(test_keys, test, json);
+  return json;
+}
+
+function forward(runner, event, processor) {
+  runner.on(event, function (object, err) {
+    write(event, processor(object, err));
+  });
+}
+
+function MochifyReporter(runner) {
+  var stats = runner.stats;
+
+  forward(runner, constants.EVENT_RUN_BEGIN, function () {
+    return {
+      start: stats.start.toISOString()
+    };
+  });
+
+  forward(runner, constants.EVENT_RUN_END, function () {
+    return {
+      end: stats.end.toISOString(),
+      duration: stats.duration
+    };
+  });
+
+  forward(runner, constants.EVENT_SUITE_BEGIN, function (suite) {
+    return {
+      root: suite.root,
+      title: suite.title,
+      pending: suite.pending,
+      delayed: suite.delayed
+    };
+  });
+
+  forward(runner, constants.EVENT_SUITE_END, function () {
+    return {};
+  });
+  forward(runner, constants.EVENT_DELAY_BEGIN, function () {
+    return {};
+  });
+  forward(runner, constants.EVENT_DELAY_END, function () {
+    return {};
+  });
+
+  forward(runner, constants.EVENT_TEST_PASS, getTestData);
+  forward(runner, constants.EVENT_TEST_PENDING, getTestData);
+  forward(runner, constants.EVENT_TEST_FAIL, function (test, err) {
+    var json = getTestData(test);
+    json.err = {};
+    copy(error_keys, err, json.err);
+    return json;
+  });
+  forward(runner, constants.EVENT_TEST_END, getTestData);
+}
+
+mocha.reporter(MochifyReporter);
+mocha.ui(/* MOCHIFY_UI */);
+mocha.timeout(/* MOCHIFY_TIMEOUT */);
+
+// Workaround for https://github.com/mozilla/geckodriver/issues/1798
+if (typeof globalThis !== 'undefined' && globalThis !== window) {
+  // Register globals on window. Mocha uses globalThis, if defined.
+  window.mocha = mocha;
+  mocha.suite.emit('pre-require', window, null, mocha);
+}
+
+mocha.mochify_pollEvents = pollEvents;
+
+var chunks = [];
+mocha.mochify_receive = function (chunk) {
+  chunks.push(chunk);
+};
+mocha.mochify_run = function () {
+  // Inject script
+  var s = document.createElement('script');
+  s.type = 'text/javascript';
+  s.textContent = chunks.join('');
+  document.body.appendChild(s);
+  // Run mocha
+  mocha.run(function (code) {
+    if (typeof __coverage__ !== 'undefined') {
+      write('mochify.coverage', window.__coverage__);
+    }
+    write('mochify.callback', { code: code });
+  });
+};
+
+['debug', 'log', 'info', 'warn', 'error'].forEach(function (name) {
+  if (console[name]) {
+    console[name] = function () {
+      write('console.' + name, slice.call(arguments));
+    };
+  }
+});
+
+window.onerror = function (msg, file, line, column, err) {
+  if (err) {
+    console.error(err.stack);
+  } else {
+    console.error(msg + '\n    at ' + file + ':' + line + ':' + column);
+  }
+};

--- a/mochify/lib/poll-events.js
+++ b/mochify/lib/poll-events.js
@@ -5,9 +5,7 @@ exports.pollEvents = pollEvents;
 function pollEvents(driver, emit) {
   return new Promise((resolve) => {
     async function doPoll() {
-      const events = await driver.evaluateReturn(
-        'window.mocha.mochify_pollEvents()'
-      );
+      const events = await driver.evaluate('window.mocha.mochify_pollEvents()');
       if (!events) {
         setImmediate(doPoll);
         return;

--- a/mochify/lib/setup-client.js
+++ b/mochify/lib/setup-client.js
@@ -3,7 +3,8 @@
 exports.setupClient = setupClient;
 
 function setupClient(client, config = {}) {
-  return client
+  const configured_client = client
     .replace('/* MOCHIFY_UI */', `'${config.ui || 'bdd'}'`)
     .replace('/* MOCHIFY_TIMEOUT */', config.timeout || 2000);
+  return `(function(){${configured_client}})()`;
 }

--- a/mochify/lib/setup-client.test.js
+++ b/mochify/lib/setup-client.test.js
@@ -1,0 +1,40 @@
+'use strict';
+
+const { assert } = require('@sinonjs/referee-sinon');
+const { setupClient } = require('./setup-client');
+
+describe('mochify/lib/setup-client', () => {
+  it('returns the given script wrapped in a self-invoking function', () => {
+    const result = setupClient('console.log("Test")');
+
+    assert.equals(result, '(function(){console.log("Test")})()');
+  });
+
+  it('replaces MOCHIFY_UI comment with default "bdd"', () => {
+    const result = setupClient('configure(/* MOCHIFY_UI */)');
+
+    assert.equals(result, "(function(){configure('bdd')})()");
+  });
+
+  it('replaces MOCHIFY_UI comment with `ui` from config', () => {
+    const result = setupClient('configure(/* MOCHIFY_UI */)', {
+      ui: 'test'
+    });
+
+    assert.equals(result, "(function(){configure('test')})()");
+  });
+
+  it('replaces MOCHIFY_TIMEOUT comment with default 2000', () => {
+    const result = setupClient('configure(/* MOCHIFY_TIMEOUT */)');
+
+    assert.equals(result, '(function(){configure(2000)})()');
+  });
+
+  it('replaces MOCHIFY_TIMEOUT comment with `timeout` from config', () => {
+    const result = setupClient('configure(/* MOCHIFY_TIMEOUT */)', {
+      timeout: 1234
+    });
+
+    assert.equals(result, '(function(){configure(1234)})()');
+  });
+});


### PR DESCRIPTION
Picks up: https://github.com/mantoni/mochify.js/pull/232/files/5aecae9f8be4f783f27877808fe4496481cc71dd#r667336402

Just prepending `return` seems to limit ourselves to immediately return the first expression in the given script, but wrapping the script in an IIFE seems to work as expected.

This should probably merged after #274 so it can be rebased against `rewrite` before and pass the tests (it does pass locally for me).